### PR TITLE
fix: package dependency fixed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -222,9 +222,9 @@
     },
     "packages/astro": {
       "name": "@better-translate/astro",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -235,13 +235,13 @@
     },
     "packages/cli": {
       "name": "@better-translate/cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bin": {
         "bt": "./dist/bin.js",
       },
       "dependencies": {
         "@ai-sdk/openai": "^3.0.41",
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
         "ai": "^6.0.116",
         "dotenv": "^17.2.3",
         "gray-matter": "^4.0.3",
@@ -263,9 +263,9 @@
     },
     "packages/md": {
       "name": "@better-translate/md",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
         "@mdx-js/mdx": "^3.1.1",
         "gray-matter": "^4.0.3",
         "rehype-stringify": "^10.0.1",
@@ -285,9 +285,9 @@
     },
     "packages/nextjs": {
       "name": "@better-translate/nextjs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
         "@formatjs/intl-localematcher": "^0.6.2",
         "negotiator": "^1.0.0",
       },
@@ -302,9 +302,9 @@
     },
     "packages/react": {
       "name": "@better-translate/react",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -316,9 +316,9 @@
     },
     "packages/tanstack-router": {
       "name": "@better-translate/tanstack-router",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@better-translate/core": "workspace:^",
+        "@better-translate/core": "^1.0.0",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-translate-workspace",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "build": "turbo run build",
     "build:packages": "turbo run build --filter=@better-translate/core --filter=@better-translate/*",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/astro",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Astro integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -46,7 +46,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "workspace:^"
+    "@better-translate/core": "^1.0.0"
   },
   "peerDependencies": {
     "astro": "^5.0.0 || ^6.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AI-powered translation generation CLI for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.41",
     "ai": "^6.0.116",
-    "@better-translate/core": "workspace:^",
+    "@better-translate/core": "^1.0.0",
     "dotenv": "^17.2.3",
     "gray-matter": "^4.0.3",
     "ora": "^8.2.0",

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/md",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Markdown and MDX helpers for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mdx-js/mdx": "^3.1.1",
-    "@better-translate/core": "workspace:^",
+    "@better-translate/core": "^1.0.0",
     "gray-matter": "^4.0.3",
     "rehype-stringify": "^10.0.1",
     "remark-parse": "^11.0.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/nextjs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Next.js integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "^0.6.2",
-    "@better-translate/core": "workspace:^",
+    "@better-translate/core": "^1.0.0",
     "negotiator": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React context and hooks for Better Translate in web and native React apps.",
   "license": "MIT",
   "type": "module",
@@ -35,7 +35,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "workspace:^"
+    "@better-translate/core": "^1.0.0"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/packages/tanstack-router/package.json
+++ b/packages/tanstack-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/tanstack-router",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TanStack Router integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -46,7 +46,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "workspace:^"
+    "@better-translate/core": "^1.0.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": "^1.167.3",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@better-translate/core` to `^1.0.0` and bumps integration packages to `1.0.1` to fix pnpm install failures caused by workspace dependency refs.

- **Bug Fixes**
  - Replaced `workspace:^` with `^1.0.0` for `@better-translate/core` in `@better-translate/astro`, `@better-translate/cli`, `@better-translate/md`, `@better-translate/nextjs`, `@better-translate/react`, and `@better-translate/tanstack-router`.
  - Bumped versions to `1.0.1` for those packages and the workspace root.
  - Updated `bun.lock` to reflect new versions and dependency resolutions.

<sup>Written for commit ecfbc92ceb679bcefdb0db5e479ac5bac3060891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.1 across workspace packages (astro, CLI, md, Next.js, React, TanStack Router).
  * Updated dependency spec for core in those packages from workspace linking to the published semver range (^1.0.0), affecting how core is resolved during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->