### PR TITLE
changelog change

### DIFF
--- a/.changeset/loose-points-wink.md
+++ b/.changeset/loose-points-wink.md
@@ -1,7 +1,0 @@
----
-"@better-translate/react": major
-"@better-translate/core": major
-"@better-translate/cli": major
----
-
-Add a new bt parameter to automatically translate and key strings.

--- a/apps/landing/CHANGELOG.md
+++ b/apps/landing/CHANGELOG.md
@@ -1,0 +1,14 @@
+# landing
+
+## 0.1.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/react@2.0.0
+  - @better-translate/core@2.0.0
+  - @better-translate/cli@2.0.0
+  - @better-translate/md@1.0.2
+  - @better-translate/nextjs@1.0.2

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,13 +11,13 @@
     "generate": "bt generate"
   },
   "dependencies": {
-    "@better-translate/md": "^1.0.1",
-    "@better-translate/cli": "^1.0.1",
-    "@better-translate/nextjs": "^1.0.1",
-    "@better-translate/react": "^1.0.1",
+    "@better-translate/md": "^1.0.2",
+    "@better-translate/cli": "^2.0.0",
+    "@better-translate/nextjs": "^1.0.2",
+    "@better-translate/react": "^2.0.0",
     "@mdx-js/mdx": "^3.1.1",
     "@remixicon/react": "^4.9.0",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "motion": "^12.36.0",
@@ -37,6 +37,12 @@
     "tailwindcss": "^4",
     "typescript": "^5"
   },
-  "ignoreScripts": ["sharp", "unrs-resolver"],
-  "trustedDependencies": ["sharp", "unrs-resolver"]
+  "ignoreScripts": [
+    "sharp",
+    "unrs-resolver"
+  ],
+  "trustedDependencies": [
+    "sharp",
+    "unrs-resolver"
+  ]
 }

--- a/examples/astro-example/CHANGELOG.md
+++ b/examples/astro-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# astro-example
+
+## 0.1.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0
+  - @better-translate/astro@1.0.2

--- a/examples/astro-example/package.json
+++ b/examples/astro-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-example",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "astro dev --port 3006",
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.0",
-    "@better-translate/astro": "^1.0.1",
+    "@better-translate/astro": "^1.0.2",
     "astro": "^6.0.0",
-    "@better-translate/core": "^1.0.0"
+    "@better-translate/core": "^2.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/examples/core-elysia-example/CHANGELOG.md
+++ b/examples/core-elysia-example/CHANGELOG.md
@@ -1,0 +1,10 @@
+# core-elysia-example
+
+## 1.0.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/examples/core-elysia-example/package.json
+++ b/examples/core-elysia-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-elysia-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.41",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "elysia": "latest"
   },
   "devDependencies": {

--- a/examples/expo-example/CHANGELOG.md
+++ b/examples/expo-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# expo-example
+
+## 1.0.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/react@2.0.0
+  - @better-translate/core@2.0.0

--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-example",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -11,13 +11,13 @@
     "lint": "biome lint ."
   },
   "dependencies": {
-    "@better-translate/react": "^1.0.1",
+    "@better-translate/react": "^2.0.0",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",

--- a/examples/md-nextjs-example/CHANGELOG.md
+++ b/examples/md-nextjs-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# md-nextjs-example
+
+## 0.1.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0
+  - @better-translate/md@1.0.2

--- a/examples/md-nextjs-example/package.json
+++ b/examples/md-nextjs-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md-nextjs-example",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3004",
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@better-translate/md": "^1.0.1",
+    "@better-translate/md": "^1.0.2",
     "@mdx-js/mdx": "^3.1.1",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "next": "16.1.6",
     "react": "^19",
     "react-dom": "^19"
@@ -23,6 +23,12 @@
     "tailwindcss": "^4",
     "typescript": "^5"
   },
-  "ignoreScripts": ["sharp", "unrs-resolver"],
-  "trustedDependencies": ["sharp", "unrs-resolver"]
+  "ignoreScripts": [
+    "sharp",
+    "unrs-resolver"
+  ],
+  "trustedDependencies": [
+    "sharp",
+    "unrs-resolver"
+  ]
 }

--- a/examples/nextjs-example/CHANGELOG.md
+++ b/examples/nextjs-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# nextjs-example
+
+## 0.1.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0
+  - @better-translate/nextjs@1.0.2

--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-example",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3002",
@@ -9,8 +9,8 @@
     "lint": "biome lint ."
   },
   "dependencies": {
-    "@better-translate/nextjs": "^1.0.1",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/nextjs": "^1.0.2",
+    "@better-translate/core": "^2.0.0",
     "next": "16.1.6",
     "react": "^19",
     "react-dom": "^19"
@@ -23,6 +23,12 @@
     "tailwindcss": "^4",
     "typescript": "^5"
   },
-  "ignoreScripts": ["sharp", "unrs-resolver"],
-  "trustedDependencies": ["sharp", "unrs-resolver"]
+  "ignoreScripts": [
+    "sharp",
+    "unrs-resolver"
+  ],
+  "trustedDependencies": [
+    "sharp",
+    "unrs-resolver"
+  ]
 }

--- a/examples/nextjs-nested-locale-example/CHANGELOG.md
+++ b/examples/nextjs-nested-locale-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# nextjs-nested-locale-example
+
+## 0.1.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0
+  - @better-translate/nextjs@1.0.2

--- a/examples/nextjs-nested-locale-example/package.json
+++ b/examples/nextjs-nested-locale-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-nested-locale-example",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3003",
@@ -9,8 +9,8 @@
     "lint": "biome lint ."
   },
   "dependencies": {
-    "@better-translate/nextjs": "^1.0.1",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/nextjs": "^1.0.2",
+    "@better-translate/core": "^2.0.0",
     "next": "16.1.6",
     "react": "^19",
     "react-dom": "^19"
@@ -23,6 +23,12 @@
     "tailwindcss": "^4",
     "typescript": "^5"
   },
-  "ignoreScripts": ["sharp", "unrs-resolver"],
-  "trustedDependencies": ["sharp", "unrs-resolver"]
+  "ignoreScripts": [
+    "sharp",
+    "unrs-resolver"
+  ],
+  "trustedDependencies": [
+    "sharp",
+    "unrs-resolver"
+  ]
 }

--- a/examples/react-vite-example/CHANGELOG.md
+++ b/examples/react-vite-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# react-vite-example
+
+## 1.0.1
+
+### Patch Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/react@2.0.0
+  - @better-translate/core@2.0.0

--- a/examples/react-vite-example/package.json
+++ b/examples/react-vite-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-vite-example",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,8 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@better-translate/react": "^1.0.1",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/react": "^2.0.0",
+    "@better-translate/core": "^2.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/examples/tanstack-start-example/package.json
+++ b/examples/tanstack-start-example/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@better-translate/tanstack-router": "^1.0.1",
+    "@better-translate/tanstack-router": "^1.0.2",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",
     "@tanstack/react-router": "latest",
@@ -20,7 +20,7 @@
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "lucide-react": "^0.545.0",
     "nitro": "npm:nitro-nightly@latest",
     "react": "^19.2.0",
@@ -43,6 +43,9 @@
     "vitest": "^3.0.5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "lightningcss"]
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "lightningcss"
+    ]
   }
 }

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @better-translate/astro
+
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/astro",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Astro integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -26,7 +26,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/middleware.ts src/content.ts --format esm,cjs --dts --clean",
     "check-types": "tsc --noEmit",
@@ -46,7 +50,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "^1.0.0"
+    "@better-translate/core": "^2.0.0"
   },
   "peerDependencies": {
     "astro": "^5.0.0 || ^6.0.0"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @better-translate/cli
+
+## 2.0.0
+
+### Major Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- 7241cf6: Add a new bt parameter to automatically translate and key strings.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/cli",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "AI-powered translation generation CLI for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -21,7 +21,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/config.ts src/bin.ts --format esm --clean && tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit",
@@ -43,7 +47,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.41",
     "ai": "^6.0.116",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "dotenv": "^17.2.3",
     "gray-matter": "^4.0.3",
     "ora": "^8.2.0",
@@ -54,5 +58,12 @@
     "@repo/typescript-config": "*",
     "@types/node": "^24.5.2"
   },
-  "keywords": ["ai", "cli", "i18n", "l10n", "translations", "typescript"]
+  "keywords": [
+    "ai",
+    "cli",
+    "i18n",
+    "l10n",
+    "translations",
+    "typescript"
+  ]
 }

--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -126,7 +126,10 @@ function getMessageValue(
   let current: TranslationMessages | string | undefined = messages;
 
   for (const segment of keyPath.split(".")) {
-    if (!isRecord(current) || !(segment in current)) {
+    if (
+      !isRecord(current) ||
+      !Object.prototype.hasOwnProperty.call(current, segment)
+    ) {
       return undefined;
     }
 
@@ -146,7 +149,9 @@ function setMessageValue(
   let current = messages as Record<string, unknown>;
 
   for (const segment of segments.slice(0, -1)) {
-    const existing = current[segment];
+    const existing = Object.prototype.hasOwnProperty.call(current, segment)
+      ? current[segment]
+      : undefined;
 
     if (existing !== undefined && !isRecord(existing)) {
       logWarning?.(
@@ -163,7 +168,9 @@ function setMessageValue(
   }
 
   const finalSegment = segments[segments.length - 1]!;
-  const finalExisting = current[finalSegment];
+  const finalExisting = Object.prototype.hasOwnProperty.call(current, finalSegment)
+    ? current[finalSegment]
+    : undefined;
 
   if (isRecord(finalExisting)) {
     logWarning?.(
@@ -388,6 +395,27 @@ function analyzeFile(options: {
     const leafKey = createLeafKey(literalValue, maxLength);
     const fullKey = namespace ? `${namespace}.${leafKey}` : leafKey;
 
+    const nodeStart = node.getStart(sourceFile);
+    const nodeEnd = node.getEnd();
+
+    const overlapping = literalCandidates.some((existing) => {
+      const existingStart = existing.callExpression.getStart(sourceFile);
+      const existingEnd = existing.callExpression.getEnd();
+      return nodeStart < existingEnd && nodeEnd > existingStart;
+    });
+
+    if (overlapping) {
+      logWarning(
+        createWarning(
+          sourceFile,
+          node,
+          "skipped marked t() call because it overlaps with another marked t() call.",
+        ),
+      );
+      ts.forEachChild(node, visit);
+      return;
+    }
+
     literalCandidates.push({
       callExpression: node,
       fullKey,
@@ -513,9 +541,11 @@ async function collectSourceFiles(
   directory: string,
   ignoredPaths: ReadonlySet<string>,
 ): Promise<string[]> {
-  const entries = await readdir(directory, {
-    withFileTypes: true,
-  });
+  const entries = (
+    await readdir(directory, {
+      withFileTypes: true,
+    })
+  ).sort((a, b) => a.name.localeCompare(b.name));
   const files: string[] = [];
 
   for (const entry of entries) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @better-translate/core
+
+## 2.0.0
+
+### Major Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- 7241cf6: Add a new bt parameter to automatically translate and key strings.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/core",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Framework-agnostic translation configuration runtime for TypeScript projects.",
   "license": "MIT",
   "type": "module",
@@ -10,8 +10,12 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
-      "core": ["./dist/core.d.ts"],
-      "server": ["./dist/server.d.ts"]
+      "core": [
+        "./dist/core.d.ts"
+      ],
+      "server": [
+        "./dist/server.d.ts"
+      ]
     }
   },
   "exports": {
@@ -29,7 +33,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/core.ts src/server.ts --format esm --clean && bun x tsc --declaration --emitDeclarationOnly --module NodeNext --moduleResolution NodeNext --target ES2022 --outDir dist src/types.ts && cp src/core.d.ts src/index.d.ts src/server.d.ts dist/",
     "check-types": "tsc --noEmit",
@@ -51,5 +59,10 @@
   "devDependencies": {
     "@repo/typescript-config": "*"
   },
-  "keywords": ["i18n", "l10n", "translations", "typescript"]
+  "keywords": [
+    "i18n",
+    "l10n",
+    "translations",
+    "typescript"
+  ]
 }

--- a/packages/md/CHANGELOG.md
+++ b/packages/md/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @better-translate/md
+
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/md",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Markdown and MDX helpers for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -21,7 +21,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/server.ts --format esm,cjs --dts --clean",
     "check-types": "tsc --noEmit",
@@ -42,7 +46,7 @@
   },
   "dependencies": {
     "@mdx-js/mdx": "^3.1.1",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "gray-matter": "^4.0.3",
     "rehype-stringify": "^10.0.1",
     "remark-parse": "^11.0.0",
@@ -60,5 +64,12 @@
   "devDependencies": {
     "@repo/typescript-config": "*"
   },
-  "keywords": ["i18n", "l10n", "markdown", "mdx", "translations", "typescript"]
+  "keywords": [
+    "i18n",
+    "l10n",
+    "markdown",
+    "mdx",
+    "translations",
+    "typescript"
+  ]
 }

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @better-translate/nextjs
+
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/nextjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Next.js integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -31,7 +31,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/server.ts src/navigation.tsx src/proxy.ts --format esm,cjs --dts --clean",
     "check-types": "tsc --noEmit",
@@ -52,7 +56,7 @@
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "^0.6.2",
-    "@better-translate/core": "^1.0.0",
+    "@better-translate/core": "^2.0.0",
     "negotiator": "^1.0.0"
   },
   "peerDependencies": {
@@ -63,5 +67,11 @@
   "devDependencies": {
     "@repo/typescript-config": "*"
   },
-  "keywords": ["i18n", "l10n", "nextjs", "translations", "typescript"]
+  "keywords": [
+    "i18n",
+    "l10n",
+    "nextjs",
+    "translations",
+    "typescript"
+  ]
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @better-translate/react
+
+## 2.0.0
+
+### Major Changes
+
+- Adds auto-extraction and auto-keying for source strings via { bt: true } in t() and a new bt extract CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. @better-translate/core and @better-translate/react return the raw string for marked calls until extraction; docs and examples updated.
+- 7241cf6: Add a new bt parameter to automatically translate and key strings.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/react",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "React context and hooks for Better Translate in web and native React apps.",
   "license": "MIT",
   "type": "module",
@@ -15,7 +15,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --clean && tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit",
@@ -35,7 +39,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "^1.0.1"
+    "@better-translate/core": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/packages/tanstack-router/CHANGELOG.md
+++ b/packages/tanstack-router/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @better-translate/tanstack-router
+
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [7241cf6]
+  - @better-translate/core@2.0.0

--- a/packages/tanstack-router/package.json
+++ b/packages/tanstack-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-translate/tanstack-router",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TanStack Router integration package for Better Translate.",
   "license": "MIT",
   "type": "module",
@@ -26,7 +26,11 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup src/index.ts src/navigation.tsx src/server.ts --format esm,cjs --dts --clean",
     "check-types": "tsc --noEmit",
@@ -46,7 +50,7 @@
     "url": "https://github.com/jralvarenga/better-translate/issues"
   },
   "dependencies": {
-    "@better-translate/core": "^1.0.0"
+    "@better-translate/core": "^2.0.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": "^1.167.3",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds auto-extraction and auto-keying for source strings using `{ bt: true }` in `t()` and introduces the `bt extract` CLI to scan code, sync the source locale (JSON or CLI‑generated TS), and rewrite calls to strict keys. Publishes changelogs and bumps versions across the repo, including major releases for `@better-translate/core`, `@better-translate/react`, and `@better-translate/cli`.

- **New Features**
  - `bt extract` scans files, updates the source locale, and replaces marked `t()` calls with strict keys.
  - Opt in via `{ bt: true }`; `@better-translate/core` and `@better-translate/react` return raw strings until extraction runs.

- **Bug Fixes**
  - Safer message reads/writes using `hasOwnProperty` checks in the CLI extractor.
  - Skip overlapping marked `t()` calls and log a warning to avoid incorrect rewrites.
  - Deterministic file traversal by sorting directory entries during collection.

<sup>Written for commit c294252211bb1c51390df23198a234d8db817f71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added auto-extraction and auto-keying for source strings using `{ bt: true }` marker in `t()` calls.
  * Introduced new `bt extract` CLI command to scan code, synchronize locales, and rewrite translation calls to strict keys.

* **Chores**
  * Updated package versions across the ecosystem with major releases for core packages.
  * Updated documentation and examples to reflect new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->