### PR TITLE
fix: footer now redirects to the correct place

### DIFF
--- a/apps/landing/components/footer.tsx
+++ b/apps/landing/components/footer.tsx
@@ -10,11 +10,17 @@ interface FooterProps {
 
 export function Footer({ locale, t }: FooterProps) {
   return (
-    <footer className="border-t border-white/10 py-12 z-10">
+    <footer className="border-t border-white/10 py-12 z-20">
       <div className="mx-auto max-w-5xl px-6">
         <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
           <Logo onlyIcon />
           <div className="flex gap-6 text-sm text-muted-foreground">
+            <Link
+              href={`/${locale}/docs`}
+              className="hover:text-foreground transition-colors"
+            >
+              {t("footer.docs")}
+            </Link>
             <Link
               href={siteLinks.github}
               target="_blank"

--- a/apps/landing/components/hero-section.tsx
+++ b/apps/landing/components/hero-section.tsx
@@ -53,7 +53,7 @@ export default function HeroSection({ locale, t }: HeroSectionProps) {
       <main className="overflow-hidden">
         <div
           aria-hidden
-          className="absolute inset-0 isolate hidden opacity-65 contain-strict lg:block"
+          className="pointer-events-none absolute inset-0 isolate hidden opacity-65 contain-strict lg:block"
         >
           <div className="w-140 h-320 -translate-y-87.5 absolute left-0 top-0 -rotate-45 rounded-full bg-[radial-gradient(68.54%_68.72%_at_55.02%_31.46%,hsla(0,0%,85%,.08)_0,hsla(0,0%,55%,.02)_50%,hsla(0,0%,45%,0)_80%)]" />
           <div className="h-320 absolute left-0 top-0 w-60 -rotate-45 rounded-full bg-[radial-gradient(50%_50%_at_50%_50%,hsla(0,0%,85%,.06)_0,hsla(0,0%,45%,.02)_80%,transparent_100%)] [translate:5%_-50%]" />

--- a/apps/landing/lib/site.ts
+++ b/apps/landing/lib/site.ts
@@ -1,5 +1,5 @@
 const githubUrl =
-  process.env.NEXT_PUBLIC_GITHUB_URL ??
+  process.env.NEXT_PUBLIC_GITHUB_URL ||
   "https://github.com/jralvarenga/better-translate";
 
 export const siteLinks = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the landing footer so links are clickable and route to the right pages. Adds a localized Docs link and ensures the background art doesn’t block clicks.

- **Bug Fixes**
  - Footer: added localized Docs link (`/${locale}/docs`) and raised z-index to `z-20`.
  - Hero: set background container to `pointer-events-none` to prevent overlay from intercepting clicks.
  - Site config: switched `NEXT_PUBLIC_GITHUB_URL` fallback to `||` so an empty env var uses the default URL.

<sup>Written for commit 5cb6a9c03d0a7a5e38b11481d903bc9451e9910b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized "Docs" navigation link to the footer.

* **Bug Fixes**
  * Adjusted footer stacking context for proper layering.
  * Disabled pointer interactions on hero section background decorative elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->