### PR TITLE
feat: docs improved

### DIFF
--- a/apps/landing/components/docs-components.tsx
+++ b/apps/landing/components/docs-components.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { CodeBlock } from "@/components/ui/code-highlight";
+import { PackageManagerBlock } from "@/components/ui/package-manager-block";
 import { cn } from "@/lib/utils";
 
 type PreCodeElement = React.ReactElement<{
@@ -215,6 +216,17 @@ export const mdxComponents = {
         >
           {children}
         </pre>
+      );
+    }
+
+    const isSh = language === "sh" || language === "bash" || language === "shell";
+    const hasNpmCommand = /^(npm |npx )/m.test(code);
+
+    if (isSh && hasNpmCommand) {
+      return (
+        <figure className="mt-6">
+          <PackageManagerBlock code={code} />
+        </figure>
       );
     }
 

--- a/apps/landing/components/ui/package-manager-block.tsx
+++ b/apps/landing/components/ui/package-manager-block.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { Highlight } from "@/components/ui/code-highlight";
+
+type PM = "npm" | "pnpm" | "yarn" | "bun";
+
+const PMS: PM[] = ["npm", "pnpm", "yarn", "bun"];
+
+const PM_CHANGE_EVENT = "bt-pm-change";
+
+function transformLine(line: string, pm: PM): string {
+  if (pm === "npm") return line;
+
+  // npx <cmd>
+  const npxMatch = line.match(/^npx\s+(.+)$/);
+  if (npxMatch) {
+    const cmd = npxMatch[1];
+    if (pm === "pnpm") return `pnpm dlx ${cmd}`;
+    if (pm === "yarn") return `yarn dlx ${cmd}`;
+    if (pm === "bun") return `bunx ${cmd}`;
+  }
+
+  // npm install -D <packages>
+  const installDevMatch = line.match(/^npm install\s+-D\s+(.+)$/);
+  if (installDevMatch) {
+    const packages = installDevMatch[1];
+    if (pm === "pnpm") return `pnpm add -D ${packages}`;
+    if (pm === "yarn") return `yarn add -D ${packages}`;
+    if (pm === "bun") return `bun add -D ${packages}`;
+  }
+
+  // npm install <packages>
+  const installMatch = line.match(/^npm install\s+(.+)$/);
+  if (installMatch) {
+    const packages = installMatch[1];
+    if (pm === "pnpm") return `pnpm add ${packages}`;
+    if (pm === "yarn") return `yarn add ${packages}`;
+    if (pm === "bun") return `bun add ${packages}`;
+  }
+
+  // npm install (bare)
+  if (line.trim() === "npm install") {
+    if (pm === "pnpm") return "pnpm install";
+    if (pm === "yarn") return "yarn install";
+    if (pm === "bun") return "bun install";
+  }
+
+  return line;
+}
+
+function transformForPm(code: string, pm: PM): string {
+  return code
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .map((line) => transformLine(line, pm))
+    .join("\n")
+    .trim();
+}
+
+function getStoredPm(): PM {
+  if (typeof window === "undefined") return "npm";
+  const stored = localStorage.getItem("preferred-pm");
+  if (stored === "npm" || stored === "pnpm" || stored === "yarn" || stored === "bun") {
+    return stored;
+  }
+  return "npm";
+}
+
+export function PackageManagerBlock({ code }: { code: string }) {
+  const [pm, setPm] = useState<PM>("npm");
+
+  useEffect(() => {
+    setPm(getStoredPm());
+
+    const handler = (e: Event) => {
+      const event = e as CustomEvent<PM>;
+      setPm(event.detail);
+    };
+
+    window.addEventListener(PM_CHANGE_EVENT, handler);
+    return () => window.removeEventListener(PM_CHANGE_EVENT, handler);
+  }, []);
+
+  function handleSelect(next: PM) {
+    localStorage.setItem("preferred-pm", next);
+    window.dispatchEvent(new CustomEvent<PM>(PM_CHANGE_EVENT, { detail: next }));
+    setPm(next);
+  }
+
+  const transformed = transformForPm(code, pm);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-white/10 bg-zinc-950">
+      <div className="flex items-center justify-between gap-3 border-b border-white/8 bg-white/[0.02] px-4 py-2">
+        <div className="flex items-center gap-1">
+          {PMS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => handleSelect(p)}
+              className={
+                p === pm
+                  ? "rounded px-2 py-0.5 font-mono text-xs font-medium text-zinc-100 bg-white/8"
+                  : "rounded px-2 py-0.5 font-mono text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+              }
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        <CopyButton
+          text={transformed}
+          label="Copy code"
+          copiedLabel="Copied"
+          iconOnly
+        />
+      </div>
+      <pre className="overflow-x-auto p-4 text-sm leading-relaxed">
+        <code className="font-mono">
+          <Highlight code={transformed} />
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/landing/docs/en/adapters-astro.mdx
+++ b/apps/landing/docs/en/adapters-astro.mdx
@@ -101,3 +101,11 @@ const t = await getTranslations();
 ## Optional next step
 
 If your Astro docs or blog posts live in localized content collections, add Astro content helpers or the MDX adapter after this basic setup is working.
+
+## Generate locale files automatically
+
+Instead of writing every translation by hand, use the CLI to extract strings and generate locale files: [CLI guide](/docs/cli)
+
+## Examples
+
+- [astro-example](https://github.com/jralvarenga/better-translate/tree/main/examples/astro-example)

--- a/apps/landing/docs/en/adapters-core.mdx
+++ b/apps/landing/docs/en/adapters-core.mdx
@@ -120,3 +120,7 @@ Run `npx bt extract` to sync the strings into your source locale file and rewrit
 - <Link href="/docs/adapters/react">React provider and hooks</Link>
 - <Link href="/docs/adapters/nextjs">Next.js App Router setup</Link>
 - <Link href="/docs/adapters/astro">Astro request helpers</Link>
+
+## Examples
+
+- [core-elysia-example](https://github.com/jralvarenga/better-translate/tree/main/examples/core-elysia-example) — plain TypeScript/Node.js setup

--- a/apps/landing/docs/en/adapters-expo.mdx
+++ b/apps/landing/docs/en/adapters-expo.mdx
@@ -93,3 +93,11 @@ export function HomeScreen() {
 - `@better-translate/react` gives Expo the provider and hook
 
 That is the full setup for most Expo apps.
+
+## Generate locale files automatically
+
+Instead of writing every translation by hand, use the CLI to extract strings and generate locale files: [CLI guide](/docs/cli)
+
+## Examples
+
+- [expo-example](https://github.com/jralvarenga/better-translate/tree/main/examples/expo-example)

--- a/apps/landing/docs/en/adapters-md.mdx
+++ b/apps/landing/docs/en/adapters-md.mdx
@@ -97,3 +97,11 @@ compiled.usedFallback;
 ## When to use the server helpers
 
 If your app already resolves the request locale on the server, use `@better-translate/md/server` so markdown loading follows the same request locale automatically.
+
+## Generate localized markdown automatically
+
+Use the CLI's `markdown.rootDir` option to have the generator translate your markdown files: [CLI guide](/docs/cli)
+
+## Examples
+
+- [md-nextjs-example](https://github.com/jralvarenga/better-translate/tree/main/examples/md-nextjs-example)

--- a/apps/landing/docs/en/adapters-nextjs.mdx
+++ b/apps/landing/docs/en/adapters-nextjs.mdx
@@ -174,3 +174,12 @@ export function LanguageLinks() {
 ## When to add the React adapter
 
 Add `@better-translate/react` only when client components need `useTranslations()` or a provider.
+
+## Generate locale files automatically
+
+Instead of writing every translation by hand, use the CLI to extract strings and generate locale files: [CLI guide](/docs/cli)
+
+## Examples
+
+- [nextjs-example](https://github.com/jralvarenga/better-translate/tree/main/examples/nextjs-example)
+- [nextjs-nested-locale-example](https://github.com/jralvarenga/better-translate/tree/main/examples/nextjs-nested-locale-example)

--- a/apps/landing/docs/en/adapters-react.mdx
+++ b/apps/landing/docs/en/adapters-react.mdx
@@ -98,7 +98,16 @@ Use only `@better-translate/core` + `@better-translate/react` when:
 
 If you are in Next.js App Router, keep this package for client hooks and add the Next.js adapter for routing and server helpers.
 
+## Generate locale files automatically
+
+Instead of writing every translation by hand, use the CLI to extract strings and generate locale files: [CLI guide](/docs/cli)
+
 ## Continue with
 
 - <Link href="/docs/adapters/expo">Expo setup</Link>
 - <Link href="/docs/adapters/nextjs">Next.js setup</Link>
+
+## Examples
+
+- [react-vite-example](https://github.com/jralvarenga/better-translate/tree/main/examples/react-vite-example)
+- [expo-example](https://github.com/jralvarenga/better-translate/tree/main/examples/expo-example)

--- a/apps/landing/docs/en/adapters-tanstack-router.mdx
+++ b/apps/landing/docs/en/adapters-tanstack-router.mdx
@@ -140,3 +140,11 @@ export function Header() {
 ## TanStack Start
 
 If you are using TanStack Start, keep the same routing and navigation setup. Then add the server helpers from `@better-translate/tanstack-router/server` the same way you would add request helpers in Next.js.
+
+## Generate locale files automatically
+
+Instead of writing every translation by hand, use the CLI to extract strings and generate locale files: [CLI guide](/docs/cli)
+
+## Examples
+
+- [tanstack-start-example](https://github.com/jralvarenga/better-translate/tree/main/examples/tanstack-start-example)

--- a/apps/landing/docs/en/cli.mdx
+++ b/apps/landing/docs/en/cli.mdx
@@ -13,17 +13,9 @@ You do not need the CLI to use the runtime packages. It is optional.
 
 ```sh
 npm install -D @better-translate/cli @ai-sdk/openai
+# or: npm install -D @better-translate/cli @ai-sdk/anthropic
+# or: npm install -D @better-translate/cli @ai-sdk/moonshotai
 ```
-
-Or install a different provider package:
-
-```sh
-npm install -D @better-translate/cli @ai-sdk/anthropic
-# or
-npm install -D @better-translate/cli @ai-sdk/moonshotai
-```
-
-The CLI no longer bundles provider helpers. Your app installs and configures the AI SDK provider directly.
 
 ## 2. Create a source locale file
 
@@ -38,78 +30,30 @@ Create `src/messages/en.json`:
 }
 ```
 
+You can also start with an empty `{}` and let `bt extract` populate it.
+
 ## 3. Create the CLI config
 
-Create `better-translate.config.ts`. The direct-model flow is the same for any provider:
+Create `better-translate.config.ts`:
 
 ```ts
 import { openai } from "@ai-sdk/openai";
 import { defineConfig } from "@better-translate/cli/config";
 
+// Works the same with @ai-sdk/anthropic or @ai-sdk/moonshotai — just swap the import and model name.
 export default defineConfig({
   sourceLocale: "en",
   locales: ["es", "fr"],
-  model: openai("gpt-5"),
+  model: openai("gpt-4o"),
   messages: {
     entry: "./src/messages/en.json",
   },
 });
 ```
 
-```ts
-import { anthropic } from "@ai-sdk/anthropic";
-import { defineConfig } from "@better-translate/cli/config";
+## 4. Mark strings in your code
 
-export default defineConfig({
-  sourceLocale: "en",
-  locales: ["es", "fr"],
-  model: anthropic("claude-sonnet-4-5"),
-  messages: {
-    entry: "./src/messages/en.json",
-  },
-});
-```
-
-```ts
-import { moonshotai } from "@ai-sdk/moonshotai";
-import { defineConfig } from "@better-translate/cli/config";
-
-export default defineConfig({
-  sourceLocale: "en",
-  locales: ["es", "fr"],
-  model: moonshotai("kimi-k2-0905-preview"),
-  messages: {
-    entry: "./src/messages/en.json",
-  },
-});
-```
-
-If you need custom provider settings, create the model yourself and pass it to the CLI. Credentials and provider-specific setup stay in your chosen provider package:
-
-```ts
-import { createOpenAI } from "@ai-sdk/openai";
-import { defineConfig } from "@better-translate/cli/config";
-
-const model = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  baseURL: process.env.OPENAI_BASE_URL,
-})("gpt-5");
-
-export default defineConfig({
-  sourceLocale: "en",
-  locales: ["es", "fr"],
-  model,
-  messages: {
-    entry: "./src/messages/en.json",
-  },
-});
-```
-
-This is a breaking change from older CLI versions that exposed `openai(...)` from `@better-translate/cli/config`.
-
-## 4. Mark pending strings
-
-Mark strings with `{ bt: true }` to write source text directly — the CLI will name the keys for you:
+Instead of naming translation keys by hand, write the source text directly and add `{ bt: true }`:
 
 ```ts
 import { t } from "@better-translate/core";
@@ -119,23 +63,39 @@ export function navLabel() {
 }
 ```
 
-`{ bt: true }` loosens the first argument so you can write the source string directly. At runtime it returns the string unchanged until extraction happens.
+At runtime, `{ bt: true }` returns the string unchanged. The CLI will replace these calls with proper keys on the next extract.
+
+You can also pass other options like `params` — they are preserved after extraction:
+
+```ts
+// You write:
+t("Hello world", { bt: true })
+t("Hello {name}", { bt: true, params: { name: "" } })
+
+// After bt extract rewrites the file:
+t("components.nav.helloWorld")
+t("components.nav.helloName", { params: { name: "" } })
+```
+
+The key namespace comes from the source file path (`components/nav.tsx` → `components.nav`). `bt: true` is always removed on rewrite.
 
 ## 5. Extract source keys
 
 ```sh
-npx bt extract --config ./better-translate.config.ts
+npx bt extract
 ```
 
-That command scans marked `t(..., { bt: true })` calls, adds missing keys to your source locale file, and rewrites successful calls to plain strict `t("namespace.generatedKey")`.
+This scans for `t(..., { bt: true })` calls, adds the missing keys to your source locale file, and rewrites the calls to plain strict keys.
+
+The CLI automatically finds `better-translate.config.ts` in your project root. The `--config` flag is only needed if your config file is in a different location.
 
 ## 6. Run the generator
 
 ```sh
-npx bt generate --config ./better-translate.config.ts
+npx bt generate
 ```
 
-That command creates the target locale files next to your source file.
+This creates the target locale files next to your source file.
 
 ## 7. Use the generated files in your app
 
@@ -143,7 +103,7 @@ After the files exist, import them into your `@better-translate/core` config jus
 
 ## Markdown
 
-If you also want localized markdown generation, add the `markdown.rootDir` option. This works the same with any AI SDK provider model:
+If you also want localized markdown generation, add the `markdown.rootDir` option:
 
 ```ts
 import { openai } from "@ai-sdk/openai";
@@ -152,7 +112,7 @@ import { defineConfig } from "@better-translate/cli/config";
 export default defineConfig({
   sourceLocale: "en",
   locales: ["es", "fr"],
-  model: openai("gpt-5"),
+  model: openai("gpt-4o"),
   messages: {
     entry: "./src/messages/en.json",
   },
@@ -161,3 +121,11 @@ export default defineConfig({
   },
 });
 ```
+
+## Examples
+
+Full working examples are in the [GitHub repo](https://github.com/jralvarenga/better-translate/tree/main/examples):
+
+- [nextjs-example](https://github.com/jralvarenga/better-translate/tree/main/examples/nextjs-example)
+- [react-vite-example](https://github.com/jralvarenga/better-translate/tree/main/examples/react-vite-example)
+- [core-elysia-example](https://github.com/jralvarenga/better-translate/tree/main/examples/core-elysia-example)

--- a/apps/landing/docs/en/installation.mdx
+++ b/apps/landing/docs/en/installation.mdx
@@ -36,6 +36,27 @@ You can check the available adapters here:
   </Button>
 </div>
 
+## CLI
+
+The CLI is an optional dev tool that removes the manual work of managing locale files.
+
+It does two things:
+
+- **Extract** — scans your code for strings marked with `{ bt: true }`, adds them to your source locale file with auto-generated keys, and rewrites the calls in place
+- **Generate** — reads your source locale file and uses an AI model to produce translated versions for every other locale
+
+```sh
+npm install -D @better-translate/cli @ai-sdk/openai
+```
+
+Once installed, running `npx bt extract` and `npx bt generate` is all it takes to go from writing source strings to having a fully translated app.
+
+<div className="mt-4 flex flex-wrap gap-3">
+  <Button asChild variant="outline" size="lg">
+    <Link href="/docs/cli">CLI guide</Link>
+  </Button>
+</div>
+
 ## Requirements
 
 - Node.js 18+ or Bun 1.0+

--- a/apps/landing/docs/en/introduction.mdx
+++ b/apps/landing/docs/en/introduction.mdx
@@ -51,3 +51,5 @@ It’s not about adding more tooling, it’s about removing uncertainty.
 - **Using TypeScript or a server?** → [Adapters → Core](/docs/adapters/core)
 - **Building a React app?** → [Adapters → React](/docs/adapters/react)
 - **Using Next.js App Router?** → [Adapters → Next.js](/docs/adapters/nextjs)
+- **Want AI to generate your locale files?** → [CLI](/docs/cli)
+- **Want to copy a working project?** → [Examples on GitHub](https://github.com/jralvarenga/better-translate/tree/main/examples)

--- a/apps/landing/docs/en/skills.mdx
+++ b/apps/landing/docs/en/skills.mdx
@@ -18,10 +18,11 @@ Use it when you want a simple answer to questions like:
 
 1. `skills/README.md` for the package map
 2. `skills/core/README.md` to start the translator correctly
-3. `skills/react/README.md` if the UI is React or Expo
-4. `skills/nextjs/README.md` if the app is Next.js App Router
-5. `skills/md/README.md` if content lives in `.md` or `.mdx`
-6. `skills/combined/README.md` if the app mixes routing, server rendering, and client hooks
+3. `skills/cli/README.md` if you want the CLI to generate locale files or extract `bt`-marked strings
+4. `skills/react/README.md` if the UI is React or Expo
+5. `skills/nextjs/README.md` if the app is Next.js App Router
+6. `skills/md/README.md` if content lives in `.md` or `.mdx`
+7. `skills/combined/README.md` if the app mixes routing, server rendering, and client hooks
 
 ## Quick package chooser
 
@@ -32,7 +33,7 @@ Use it when you want a simple answer to questions like:
 - TanStack Router: `@better-translate/core` + `@better-translate/tanstack-router`, and usually `@better-translate/react`
 - Astro: `@better-translate/core` + `@better-translate/astro`
 - Localized markdown or MDX: add `@better-translate/md`
-- AI-generated locale files: add `@better-translate/cli`
+- AI-generated locale files or auto-extracted strings: add `@better-translate/cli`
 
 ## Start here
 
@@ -41,3 +42,4 @@ Use it when you want a simple answer to questions like:
 - <Link href="/docs/adapters/nextjs">Next.js guide</Link>
 - <Link href="/docs/adapters/md">MD & MDX guide</Link>
 - <Link href="/docs/cli">CLI guide</Link>
+- [Examples on GitHub](https://github.com/jralvarenga/better-translate/tree/main/examples)

--- a/bun.lock
+++ b/bun.lock
@@ -1276,21 +1276,21 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.95.2", "", { "dependencies": { "@tanstack/query-core": "5.95.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.5", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.5", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-jh+S5bqvHxH7ng4KKsN3wTYegJIP4V68dGrgUUwmYSmipb4cJyq+09TqCWVRXQ9f9xVeESRAqotAgK7GOS1uFQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.168.7", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.6", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-fW/HvQja4PQeu9lsoyh+pXpZ0UXezbpQkkJvCuH6tHAaW3jvPkjh14lfadrNNiY+pXT7WiMTB3afGhTCC78PDQ=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.166.11", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.1" }, "peerDependencies": { "@tanstack/react-router": "^1.168.2", "@tanstack/router-core": "^1.168.2", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-WYR3q4Xui5yPT/5PXtQh8i03iUA7q8dONBjWpV3nsGdM8Cs1FxpfhLstW0wZO1dOvSyElscwTRCJ6nO5N8r3Lg=="],
 
     "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.166.10", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.167.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-Ny5jKZPSy+RBXICJBJkW2q3SKjEwVooIn2zuWfIFL1MNVImQPh/p+yvqDqKdJseIQ45B4JsqFtWVcdy/6rQ0Rg=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.167.10", "", { "dependencies": { "@tanstack/react-router": "1.168.5", "@tanstack/react-start-client": "1.166.20", "@tanstack/react-start-server": "1.166.20", "@tanstack/router-utils": "^1.161.6", "@tanstack/start-client-core": "1.167.5", "@tanstack/start-plugin-core": "1.167.12", "@tanstack/start-server-core": "1.167.5", "pathe": "^2.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-rdER2wsD3UQ0YKVzLVnI69UKp4UBh8yRw+uc6lxsCdkh83Q6V4uHPx59uusz0P8WrXWe5G7vDoz6QEUekpIFeA=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.167.12", "", { "dependencies": { "@tanstack/react-router": "1.168.7", "@tanstack/react-start-client": "1.166.22", "@tanstack/react-start-server": "1.166.22", "@tanstack/router-utils": "^1.161.6", "@tanstack/start-client-core": "1.167.6", "@tanstack/start-plugin-core": "1.167.13", "@tanstack/start-server-core": "1.167.6", "pathe": "^2.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-My4ICbFKlpkA5Uxk/7kczXKLHtBaxNzUzrPSXlLcRz87UhMAUNw92ujIGEUhYs3BGuajjdlAvhH4HW8wIkWhkw=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.20", "", { "dependencies": { "@tanstack/react-router": "1.168.5", "@tanstack/router-core": "1.168.5", "@tanstack/start-client-core": "1.167.5" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-/xix+rfmzdcm+YDYNCdZx3iGGK+m80qQYBdQKwyJLfO3EdUVHFYZYZcqvCFHyZbqZHm6fY0fKR9sJSXDKgQgFA=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.22", "", { "dependencies": { "@tanstack/react-router": "1.168.7", "@tanstack/router-core": "1.168.6", "@tanstack/start-client-core": "1.167.6" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-q8GjmehiKPlmbZ2ZjIjeTR8u8Xr8kilbD/AIAvBpd5GCHvwSKYSjgQXSQXbe+B8wqiGXrrid7R9DAeurDHM46A=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.20", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.168.5", "@tanstack/router-core": "1.168.5", "@tanstack/start-client-core": "1.167.5", "@tanstack/start-server-core": "1.167.5" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-P9NV9R3zON7gd17H33D3WDuLDb1Rta9dZ0+DY0JRVb94AlpQsIZxuFfF4MM7sFhprBB5S7nMfnoMFajgNScXzw=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.22", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.168.7", "@tanstack/router-core": "1.168.6", "@tanstack/start-client-core": "1.167.6", "@tanstack/start-server-core": "1.167.6" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-Ce0WsGkxzZxhithG23EObJxJ3MPhiZpNbsqRSXyDJ/ccKLRNyjlO0frPxqyVM21/geugv7HVBbU8Cx4TB54dLQ=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.5", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-k378TPlJBM1x+7ixgQL+gC+v6omN6vF31QuhOBzcISQ1oW/oyHsJf8D4OWnZ4wJD63vD2P5kXLb8QcHM419oeg=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.168.6", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-okCno3pImpLFQMJ/4zqEIGjIV5yhxLGj0JByrzQDQehORN1y1q6lJUezT0KPK5qCQiKUApeWaboLPjgBVx1kaQ=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.1", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.2", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-ECMM47J4KmifUvJguGituSiBpfN8SyCUEoxQks5RY09hpIBfR2eswCv2e6cJimjkKwBQXOVTPkTUk/yRvER+9w=="],
 
@@ -1302,15 +1302,15 @@
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.5", "", { "dependencies": { "@tanstack/router-core": "1.168.5", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.19", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-UjrSDBGAWelqDHCOhNrgnaULuPtu4LG7+hf7V/7X5sPHfnOk4O1kK6KMryQMbHrILLABz4guUTBeMEmJDBH9jA=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.6", "", { "dependencies": { "@tanstack/router-core": "1.168.6", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.20", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-SmGQMSY5DEP8ZvfT1IGp0prUYdlEX0mbd1Dz+lAfma8+kA0u1Aa/IDALuQsahbga6VJ+um8KFyCNtvKHKEying=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.161.6", "", {}, "sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.167.12", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.5", "@tanstack/router-generator": "1.166.20", "@tanstack/router-plugin": "1.167.7", "@tanstack/router-utils": "1.161.6", "@tanstack/start-client-core": "1.167.5", "@tanstack/start-server-core": "1.167.5", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "pathe": "^2.0.3", "picomatch": "^4.0.3", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "vite": ">=7.0.0" } }, "sha512-FzkCKKX+QmszJ5tpZ6eFYmLAPIVJqGhLXEmrFwzA+r+zDwdySlXnDYckgqh+VmnY59FYLOJfl1FSS4Nt7NdmWQ=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.167.13", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.6", "@tanstack/router-generator": "1.166.21", "@tanstack/router-plugin": "1.167.8", "@tanstack/router-utils": "1.161.6", "@tanstack/start-client-core": "1.167.6", "@tanstack/start-server-core": "1.167.6", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "pathe": "^2.0.3", "picomatch": "^4.0.3", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "vite": ">=7.0.0" } }, "sha512-rKS02qj9/X3rRKAe/93INtR/1EGawN1vgy9fULtMKXvwWC8ZSU3VAs9zjPg8nHjy3fVE3SSL6NxFr4LJmdPYyg=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.5", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.5", "@tanstack/start-client-core": "1.167.5", "@tanstack/start-storage-context": "1.166.19", "h3-v2": "npm:h3@2.0.1-rc.16", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-ACFtJcMfBI8HedkyhPP6BZIX38M1i9sg4LT85UeVZx8wyaFFNCFUB75+TCmngTeom9McK3Qp7LklrjQDLW5DrA=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.6", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.6", "@tanstack/start-client-core": "1.167.6", "@tanstack/start-storage-context": "1.166.20", "h3-v2": "npm:h3@2.0.1-rc.16", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-IC1U3SMM2SVZ3M9KMSHjV0AqAU3snGtGz6D3psrX8RZxTuMpmv/DaCs8jqGwfZbB2D2EQNUxDrBOmFYr7m7dQw=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.19", "", { "dependencies": { "@tanstack/router-core": "1.168.5" } }, "sha512-u4+A3n//n4jeLzPYvqKBT2ssjg/cfNblCLtLex6OzoJdaPXEVrf+oq1+DYYWVeKxFDymEA8SSV69QuNmV5+71Q=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.20", "", { "dependencies": { "@tanstack/router-core": "1.168.6" } }, "sha512-eQQG+0V3NMpPKd7K6mgqO4vwOdpj66m9F7UxVOiazcUrv5CgAM6H240tyHKKeHRMjykRhkF1ubarUF2Yd+GTOg=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -3400,9 +3400,13 @@
 
     "@tanstack/devtools-event-bus/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
+    "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.168.5", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-k378TPlJBM1x+7ixgQL+gC+v6omN6vF31QuhOBzcISQ1oW/oyHsJf8D4OWnZ4wJD63vD2P5kXLb8QcHM419oeg=="],
+
     "@tanstack/router-generator/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.168.5", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-k378TPlJBM1x+7ixgQL+gC+v6omN6vF31QuhOBzcISQ1oW/oyHsJf8D4OWnZ4wJD63vD2P5kXLb8QcHM419oeg=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -3411,6 +3415,10 @@
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.166.21", "", { "dependencies": { "@tanstack/router-core": "1.168.6", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-pJWsP6HaGrkIkfkcg6vzKyCBMbf1vV1BrQH+bFAVzXj3T/afmix3IPV2hiAj4zzjMxuddJD1on0Hn5+WDYA7zQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.8", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.6", "@tanstack/router-generator": "1.166.21", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.7", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-/X4ACYsSX4bRmomj5X2TBU75cHuIVI99Fsax6DWnP6hPb4PaSjPUHVBfHhk2NemJzEOZu1L31UQ9QDlbHU4ZTQ=="],
 
     "@tanstack/start-plugin-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -3818,6 +3826,10 @@
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@tanstack/start-plugin-core/@tanstack/router-generator/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -4004,6 +4016,8 @@
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -4039,6 +4053,8 @@
     "@expo/package-manager/ora/cli-cursor/restore-cursor/onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
 
     "@expo/package-manager/ora/cli-cursor/restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "@expo/cli/ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,7 @@ Then add only the adapter your app needs:
 - Astro request helpers and middleware: `@better-translate/astro`
 - TanStack Router locale-aware routing: `@better-translate/tanstack-router`
 - Localized Markdown or MDX: `@better-translate/md`
-- Generated locale files: `@better-translate/cli`
+- Auto-extract strings and generate locale files: `@better-translate/cli`
 
 ## Fast package chooser
 
@@ -23,11 +23,13 @@ Then add only the adapter your app needs:
 - Next.js App Router apps: read `skills/nextjs/README.md`
 - Markdown or MDX content: read `skills/md/README.md`
 - Mixed app with routing, server rendering, and client hooks: read `skills/combined/README.md`
+- CLI or bt-extracted strings: read `skills/cli/README.md`
 
 ## Reading order
 
 1. `skills/core/README.md`
-2. `skills/react/README.md`
-3. `skills/nextjs/README.md`
-4. `skills/md/README.md`
-5. `skills/combined/README.md`
+2. `skills/cli/README.md`
+3. `skills/react/README.md`
+4. `skills/nextjs/README.md`
+5. `skills/md/README.md`
+6. `skills/combined/README.md`

--- a/skills/cli/README.md
+++ b/skills/cli/README.md
@@ -1,0 +1,102 @@
+# CLI Skill
+
+Use this guide when you want the CLI to manage locale files for you, or when you want to write source strings directly in code without naming keys by hand.
+
+## What this package does
+
+- `bt extract` — scans your source files for `t("...", { bt: true })` calls, adds keys to your source locale JSON, and rewrites those calls to plain key strings
+- `bt generate` — reads your source locale file and calls an AI model to create translated versions for every other locale
+
+## Minimum setup
+
+### 1. Install
+
+```sh
+npm install -D @better-translate/cli @ai-sdk/openai
+# or @ai-sdk/anthropic / @ai-sdk/moonshotai
+```
+
+### 2. Create a source locale file
+
+Create `src/messages/en.json`:
+
+```json
+{}
+```
+
+An empty object is fine. `bt extract` will populate it.
+
+### 3. Create the config
+
+Create `better-translate.config.ts`:
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { defineConfig } from "@better-translate/cli/config";
+
+export default defineConfig({
+  sourceLocale: "en",
+  locales: ["es", "fr"],
+  model: openai("gpt-4o"),
+  messages: {
+    entry: "./src/messages/en.json",
+  },
+});
+```
+
+Swap `openai(...)` for `anthropic(...)` or `moonshotai(...)` if you use a different provider.
+
+### 4. Mark strings in your code
+
+In any TypeScript or TSX file, write source text directly using `{ bt: true }`:
+
+```ts
+t("Hello world", { bt: true })
+t("Hello {name}", { bt: true, params: { name: "" } })
+```
+
+### 5. Extract
+
+```sh
+npx bt extract
+```
+
+The CLI automatically finds `better-translate.config.ts` in the project root. `--config` is only needed if the config file is in a non-standard location.
+
+After this runs, the source locale file gains new keys and the original `t()` calls are rewritten:
+
+```ts
+// before
+t("Hello world", { bt: true })
+
+// after
+t("components.header.helloWorld")
+```
+
+The namespace prefix (`components.header`) comes from the source file path. `bt: true` is removed. Other options like `params` are preserved.
+
+### 6. Generate
+
+```sh
+npx bt generate
+```
+
+This creates one translated JSON file per locale next to the source file.
+
+## Rule
+
+Always run `bt extract` before `bt generate`. Extract populates the source file; generate reads it.
+
+## When to also add framework adapters
+
+The CLI only manages files. You still need a runtime package to use them.
+
+- Add `@better-translate/core` to load and use locale files at runtime
+- Add `@better-translate/react` for React components
+- Add `@better-translate/nextjs` for Next.js routing
+
+## Examples
+
+- `examples/nextjs-example` — Next.js App Router with generated locale files
+- `examples/react-vite-example` — React SPA with generated locale files
+- `examples/core-elysia-example` — plain TypeScript/Node.js setup

--- a/skills/combined/README.md
+++ b/skills/combined/README.md
@@ -32,6 +32,16 @@ Use this guide when the app needs more than one Better Translate package.
 - `@better-translate/astro`
 - `@better-translate/md`
 
+### Any app with AI-generated locale files
+
+Add `@better-translate/cli` to any combination above when you want the CLI to manage locale file creation.
+
+Example — Next.js app with generated translations:
+
+- `@better-translate/core`
+- `@better-translate/nextjs`
+- `@better-translate/cli`
+
 ## Rule to keep the setup clean
 
 Every combination still has one source of truth:

--- a/skills/core/README.md
+++ b/skills/core/README.md
@@ -53,6 +53,16 @@ translator.t("home.title", { locale: "es" });
 - Add `@better-translate/astro` when Astro requests need locale awareness
 - Add `@better-translate/md` when content files should follow the same locale setup
 
+## Auto-extract strings without naming keys
+
+Use `{ bt: true }` in any `t()` call to write source text directly instead of inventing a key:
+
+```ts
+t("Hello world", { bt: true })
+```
+
+Then run `npx bt extract` to generate keys automatically and rewrite the calls. See `skills/cli/README.md` for the full setup.
+
 ## Main idea
 
 Do not create one translation system per framework.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a package manager switcher for shell code blocks and streamlines the docs/CLI flow with clearer steps, examples, and a new CLI skill page. This reduces copy-paste friction and makes getting started with `bt extract` and `bt generate` simpler.

- **New Features**
  - Added `PackageManagerBlock` to toggle between `npm`, `pnpm`, `yarn`, and `bun`, with copy support.
  - Auto-detects `npm`/`npx` commands in `sh`/`bash`/`shell` code blocks and renders the switcher.

- **Documentation**
  - CLI guide: clearer extract→generate flow; covers `{ bt: true }`, path-based key namespaces, and auto-finding `better-translate.config.ts`; examples use `openai("gpt-4o")` and include `@ai-sdk/anthropic`/`@ai-sdk/moonshotai`.
  - Adapter guides add “Generate locale files automatically” sections linking to the CLI and include “Examples” with repo links.
  - Installation and Introduction now highlight the CLI and link to Examples on GitHub.
  - Added `skills/cli/README.md`; updated skills reading order and package chooser for CLI and `{ bt: true }` extraction.

<sup>Written for commit 35ca8c8bf20b49df8113c352cbecc0992f769535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package manager selector to code blocks (npm, pnpm, yarn, bun support with localStorage persistence)
  * Introduced CLI tool for auto-extracting marked strings and generating AI-translated locale files

* **Documentation**
  * Added comprehensive CLI setup guide with extraction and generation workflows
  * Expanded adapter documentation with example repository links
  * Updated installation guide with CLI information
  * Enhanced skill guides with CLI usage instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->