### PR TITLE
fix: useTranslations hook fix

### DIFF
--- a/.changeset/full-readers-vanish.md
+++ b/.changeset/full-readers-vanish.md
@@ -1,0 +1,6 @@
+---
+"@better-translate/react": minor
+"landing": patch
+---
+
+Fixed typing for `useTranslations`; apps can type zero-argument `useTranslations()` through module augmentation instead of passing the translator type at each call site

--- a/apps/landing/docs/en/adapters-react.mdx
+++ b/apps/landing/docs/en/adapters-react.mdx
@@ -88,6 +88,48 @@ export function Header() {
 }
 ```
 
+## Optional: type `useTranslations()` once for the whole app
+
+If you want plain `useTranslations()` to autocomplete your translation keys without
+repeating `<typeof translator>` in every component, add one declaration file:
+
+Create `src/better-translate.d.ts`:
+
+```ts
+import { translator } from "./i18n";
+
+declare module "@better-translate/react" {
+  interface BetterTranslateReactTypes {
+    translator: typeof translator;
+  }
+}
+```
+
+Then your components can call the hook without a generic:
+
+```tsx
+import { useTranslations } from "@better-translate/react";
+
+export function Header() {
+  const { locale, setLocale, t } = useTranslations();
+
+  return (
+    <header>
+      <h1>{t("home.title")}</h1>
+      <button onClick={() => setLocale("en")} disabled={locale === "en"}>
+        English
+      </button>
+      <button onClick={() => setLocale("es")} disabled={locale === "es"}>
+        Espanol
+      </button>
+    </header>
+  );
+}
+```
+
+Explicit generics still work, so you can keep using `useTranslations<typeof translator>()`
+where that fits your codebase better.
+
 ## When to use React only
 
 Use only `@better-translate/core` + `@better-translate/react` when:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,4 +2,16 @@
 
 `@better-translate/react` adds a provider and hooks on top of `@better-translate/core`. Use it in React web apps and Expo apps when components need access to translations and locale switching.
 
+To make plain `useTranslations()` fully typed across your app, augment the package once:
+
+```ts
+import type { AppTranslator } from "./i18n";
+
+declare module "@better-translate/react" {
+  interface BetterTranslateReactTypes {
+    translator: AppTranslator;
+  }
+}
+```
+
 Full docs: [better-translate-placeholder.com/en/docs/adapters/react](https://better-translate-placeholder.com/en/docs/adapters/react)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,8 @@ export { useTranslations } from "./use-translations.js";
 export type {
   AnyBetterTranslateTranslator,
   BetterTranslateProviderProps,
+  BetterTranslateReactTypes,
+  DefaultBetterTranslateTranslator,
   InferLocale,
   InferMessages,
   UseTranslationsValue,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -14,6 +14,21 @@ export type AnyBetterTranslateTranslator = ConfiguredTranslator<
   TranslationMessages
 >;
 
+/**
+ * App-level type registry for `@better-translate/react`.
+ *
+ * Consumers can augment this interface once to make zero-argument
+ * `useTranslations()` return their configured translator type.
+ */
+export interface BetterTranslateReactTypes {}
+
+export type DefaultBetterTranslateTranslator =
+  BetterTranslateReactTypes extends { translator: infer TTranslator }
+    ? TTranslator extends AnyBetterTranslateTranslator
+      ? TTranslator
+      : AnyBetterTranslateTranslator
+    : AnyBetterTranslateTranslator;
+
 export type InferLocale<TTranslator extends AnyBetterTranslateTranslator> =
   TTranslator extends ConfiguredTranslator<infer TLocale, TranslationMessages>
     ? TLocale

--- a/packages/react/src/use-translations.ts
+++ b/packages/react/src/use-translations.ts
@@ -3,6 +3,7 @@ import { useContext } from "react";
 import { BetterTranslateContext } from "./context.js";
 import type {
   AnyBetterTranslateTranslator,
+  DefaultBetterTranslateTranslator,
   UseTranslationsValue,
 } from "./types.js";
 
@@ -13,7 +14,7 @@ import type {
  */
 export function useTranslations<
   TTranslator extends
-    AnyBetterTranslateTranslator = AnyBetterTranslateTranslator,
+    AnyBetterTranslateTranslator = DefaultBetterTranslateTranslator,
 >(): UseTranslationsValue<TTranslator> {
   const context = useContext(BetterTranslateContext);
 

--- a/packages/react/tests/runtime/react.test.tsx
+++ b/packages/react/tests/runtime/react.test.tsx
@@ -168,6 +168,33 @@ describe("@better-translate/react", () => {
     expect(latestValue?.rtl).toBe(true);
   });
 
+  it("keeps zero-argument useTranslations working at runtime", async () => {
+    const translator = await configureTranslations({
+      availableLocales: ["en", "es"] as const,
+      defaultLocale: "en",
+      fallbackLocale: "en",
+      messages: { en, es },
+    });
+
+    let latestValue: ReturnType<typeof useTranslations> | undefined;
+
+    function Consumer() {
+      latestValue = useTranslations();
+      return null;
+    }
+
+    await act(async () => {
+      create(
+        <BetterTranslateProvider translator={translator}>
+          <Consumer />
+        </BetterTranslateProvider>,
+      );
+    });
+
+    expect(latestValue?.locale).toBe("en");
+    expect(latestValue?.t("common.hello")).toBe("Hello");
+  });
+
   it("switches to a cached locale", async () => {
     const translator = await configureTranslations({
       availableLocales: ["en", "es"] as const,

--- a/packages/react/tests/types/react.typecheck.tsx
+++ b/packages/react/tests/types/react.typecheck.tsx
@@ -52,6 +52,14 @@ const translator = await configureTranslations({
   },
 } as const);
 
+type AppTranslator = typeof translator;
+
+declare module "../../dist/index.js" {
+  interface BetterTranslateReactTypes {
+    translator: AppTranslator;
+  }
+}
+
 function Consumer() {
   const translations = useTranslations<typeof translator>();
 
@@ -100,9 +108,70 @@ function Consumer() {
   // @ts-expect-error messages with placeholders should require params
   translations.t("common.greeting");
 
+  // @ts-expect-error placeholder names should be inferred from the source message
   translations.t("common.greeting", {
     params: {
-      // @ts-expect-error placeholder names should be inferred from the source message
+      user: "Ada",
+    },
+  });
+
+  // @ts-expect-error unsupported locale should fail
+  void translations.setLocale("pt");
+
+  return null;
+}
+
+function AugmentedConsumer() {
+  const translations = useTranslations();
+
+  translations.t("common.hello");
+  translations.t("Welcome back", { bt: true });
+  translations.t("Welcome {name}", {
+    bt: true,
+    params: {
+      name: "Ada",
+    },
+  });
+  translations.t("account.balance.label");
+  translations.t("common.greeting", {
+    params: {
+      name: "Ada",
+    },
+  });
+  translations.t("common.formalGreeting", {
+    params: {
+      salute: "Dr.",
+      name: "Ada",
+    },
+  });
+  void translations.setLocale("es");
+  void translations.loadLocale("fr");
+  translations.availableLanguages[0]?.locale;
+  translations.direction;
+  translations.messages.en;
+  translations.messages.fr;
+  translations.rtl;
+  translations.translator.getDirection({ locale: "es" });
+  translations.translator.isRtl({
+    config: {
+      rtl: true,
+    },
+  });
+  translations.t("common.hello", {
+    config: {
+      rtl: false,
+    },
+  });
+
+  // @ts-expect-error invalid translation key should fail
+  translations.t("account.balance.total");
+
+  // @ts-expect-error messages with placeholders should require params
+  translations.t("common.greeting");
+
+  // @ts-expect-error placeholder names should be inferred from the source message
+  translations.t("common.greeting", {
+    params: {
       user: "Ada",
     },
   });
@@ -115,6 +184,10 @@ function Consumer() {
 
 <BetterTranslateProvider translator={translator}>
   <Consumer />
+</BetterTranslateProvider>;
+
+<BetterTranslateProvider translator={translator}>
+  <AugmentedConsumer />
 </BetterTranslateProvider>;
 
 <BetterTranslateProvider translator={translator} initialLocale="es">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `useTranslations` typing in `@better-translate/react` so autocompletion works without a generic. Apps can set a default translator once via module augmentation to make zero-arg `useTranslations()` fully typed.

- **Bug Fixes**
  - `useTranslations` now defaults to `DefaultBetterTranslateTranslator`, resolved from an app-level `BetterTranslateReactTypes` registry.
  - Exported `BetterTranslateReactTypes` and `DefaultBetterTranslateTranslator`.
  - Updated docs (`apps/landing`) and package `README`; added runtime and type tests.
  - No breaking changes; `useTranslations<typeof translator>()` still works.

<sup>Written for commit 1b9388e45323892a7b0165fb30f327c80ef334e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

