### PR TITLE
2026.4.10 website description fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 One i18n setup for any TypeScript project.
 
-Same config. Same API. Use AI Gateway or local Ollama models across Next.js, Astro, React, TanStack Router, and plain Node. No rewrites.
+Configure once. Translate everywhere. Type-safe i18n for Next.js, Astro, React, TanStack Router and any TypeScript environment.
 
 ## Features
 

--- a/apps/landing/lib/i18n/messages/ar.ts
+++ b/apps/landing/lib/i18n/messages/ar.ts
@@ -82,7 +82,7 @@ export const ar = {
       localeSwitching: "تبديل اللغة بدون إعادة تحميل الصفحة",
       generateLocales: "أنشئ لغات باستخدام AI أو Ollama المحلي",
     },
-    description: "نفس الإعداد. نفس API. استخدم AI Gateway أو نماذج Ollama المحلية عبر Next.js وAstro وReact وTanStack Router وNode العادي. بدون إعادة كتابة.",
+    description: "اضبط مرة واحدة. ترجم في كل مكان. i18n آمن من حيث الأنواع لـ Next.js وAstro وReact وTanStack Router وأي بيئة TypeScript.",
     primaryCta: "عرض التوثيق",
     secondaryCta: "عرض على GitHub",
     sponsorCta: "رعاية المشروع",

--- a/apps/landing/lib/i18n/messages/en.ts
+++ b/apps/landing/lib/i18n/messages/en.ts
@@ -95,7 +95,7 @@ export const en = {
       generateLocales: "Generate locales with AI or local Ollama",
     },
     description:
-      "Same config. Same API. Use AI Gateway or local Ollama models across Next.js, Astro, React, TanStack Router, and plain Node. No rewrites.",
+      "Configure once. Translate everywhere. Type-safe i18n for Next.js, Astro, React, TanStack Router and any TypeScript environment.",
     primaryCta: "View docs",
     secondaryCta: "View on GitHub",
     sponsorCta: "Sponsor the project",

--- a/apps/landing/lib/i18n/messages/es.ts
+++ b/apps/landing/lib/i18n/messages/es.ts
@@ -82,7 +82,7 @@ export const es = {
       localeSwitching: "Cambio de idioma sin recargar la página",
       generateLocales: "Genera locales con IA o Ollama local",
     },
-    description: "Misma config. Misma API. Usa AI Gateway o modelos locales de Ollama en Next.js, Astro, React, TanStack Router y Node puro. Sin reescribir.",
+    description: "Configura una vez. Traduce en todas partes. i18n con tipos seguros para Next.js, Astro, React, TanStack Router y cualquier entorno TypeScript.",
     primaryCta: "Ver docs",
     secondaryCta: "Ver en GitHub",
     sponsorCta: "Sponsorizar el proyecto",

--- a/apps/landing/lib/i18n/messages/ja.ts
+++ b/apps/landing/lib/i18n/messages/ja.ts
@@ -82,7 +82,7 @@ export const ja = {
       localeSwitching: "ページリロードなしのロケール切り替え",
       generateLocales: "AIまたはローカルOllamaでロケールを生成",
     },
-    description: "同じ設定。同じAPI。Next.js、Astro、React、TanStack Router、プレーンなNodeで、AI GatewayまたはローカルのOllamaモデルを使用。書き換え不要。",
+    description: "一度設定すれば、どこでも翻訳できる。Next.js、Astro、React、TanStack Router、あらゆるTypeScript環境に対応した型安全なi18n。",
     primaryCta: "ドキュメントを見る",
     secondaryCta: "GitHubで見る",
     sponsorCta: "プロジェクトをスポンサーする",

--- a/bun.lock
+++ b/bun.lock
@@ -3462,8 +3462,6 @@
 
     "astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
-    "astro-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
     "astro-example/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "babel-jest/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -3490,8 +3488,6 @@
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "core-elysia-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -3509,10 +3505,6 @@
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "error-ex/is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
-
-    "expo-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
-    "expo-example/@better-translate/react": ["@better-translate/react@2.1.1", "", { "dependencies": { "@better-translate/core": "^2.2.1" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-d0ZMgKs8NTnSt8RvDS9c+gsZAd8BsG0ijhKBwwGy1tQAkU6IIzhHAi5JGT4TgSHDTFNDMhCRottHMA5CwHdrJw=="],
 
     "expo-example/react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
 
@@ -3592,10 +3584,6 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "md-nextjs-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
-    "md-nextjs-example/@better-translate/md": ["@better-translate/md@2.1.1", "", { "dependencies": { "@better-translate/core": "^2.2.1", "@mdx-js/mdx": "^3.1.1", "gray-matter": "^4.0.3", "rehype-stringify": "^10.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "unified": "^11.0.5" }, "peerDependencies": { "react": "^19.0.0" }, "optionalPeers": ["react"] }, "sha512-0scxHTj1TB9o2wOYsJdbKskAHVTbAfAO8oUvGMw6TND/5Ag/bHjt/h2y0i8iAi1zWEUzHTZ0763FJTRT8DHbtQ=="],
-
     "md-nextjs-example/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
     "md-nextjs-example/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
@@ -3636,15 +3624,11 @@
 
     "msw/type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
-    "nextjs-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
     "nextjs-example/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
     "nextjs-example/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "nextjs-example/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "nextjs-nested-locale-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
 
     "nextjs-nested-locale-example/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
@@ -3684,10 +3668,6 @@
 
     "react-native-worklets/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
-    "react-vite-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
-
-    "react-vite-example/@better-translate/react": ["@better-translate/react@2.1.1", "", { "dependencies": { "@better-translate/core": "^2.2.1" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-d0ZMgKs8NTnSt8RvDS9c+gsZAd8BsG0ijhKBwwGy1tQAkU6IIzhHAi5JGT4TgSHDTFNDMhCRottHMA5CwHdrJw=="],
-
     "react-vite-example/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "react-vite-example/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -3725,8 +3705,6 @@
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
-
-    "tanstack-start-example/@better-translate/core": ["@better-translate/core@2.2.1", "", {}, "sha512-GcSCacR5YI4CDfhOY0v3SzXDF1Q1nGNda6B4ntqXgbMxQntITlr7FZyWGQFVq1JWgVOlKBrB+hL39DXTkh2Krg=="],
 
     "tanstack-start-example/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the website and README tagline to “Configure once. Translate everywhere.” with type‑safe i18n wording across `en`, `es`, `ar`, and `ja`. Cleaned `bun.lock` by removing stale example package entries (e.g., `@better-translate/core`, `@better-translate/react`, `@better-translate/md`); no runtime impact.

<sup>Written for commit 72d09242deaa85c85e915207ae6a2db9afe4dd47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

