### PR TITLE
feat: add createBetterTranslateReact typed hook factory

### DIFF
--- a/.changeset/honest-paths-pull.md
+++ b/.changeset/honest-paths-pull.md
@@ -1,0 +1,6 @@
+---
+"react-vite-example": minor
+"@better-translate/react": minor
+---
+
+feat(react): add createBetterTranslateReact typed hook factory

--- a/apps/landing/docs/en/adapters-react.mdx
+++ b/apps/landing/docs/en/adapters-react.mdx
@@ -67,6 +67,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 If you want `useTranslations()` to autocomplete keys and locales without
 repeating generics or adding a declaration file, bind your translator once:
 
+Create `src/i18n-react.ts`:
+
 ```ts
 import { createBetterTranslateReact } from "@better-translate/react";
 
@@ -76,14 +78,30 @@ export const { BetterTranslateProvider, useTranslations } =
   createBetterTranslateReact(translator);
 ```
 
-Then import the app-local provider and hook instead of the package-level ones.
+Then update `src/main.tsx` to import the app-local provider:
+
+```tsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import { App } from "./app";
+import { BetterTranslateProvider } from "./i18n-react";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BetterTranslateProvider>
+      <App />
+    </BetterTranslateProvider>
+  </React.StrictMode>,
+);
+```
 
 ## 5. Read translations inside a component
 
 Create `src/header.tsx`:
 
 ```tsx
-import { useTranslations } from "./i18n";
+import { useTranslations } from "./i18n-react";
 
 export function Header() {
   const { locale, setLocale, t } = useTranslations();

--- a/apps/landing/docs/en/adapters-react.mdx
+++ b/apps/landing/docs/en/adapters-react.mdx
@@ -62,53 +62,28 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 ```
 
-## 4. Read translations inside a component
+## 4. Create a typed provider + hook pair
+
+If you want `useTranslations()` to autocomplete keys and locales without
+repeating generics or adding a declaration file, bind your translator once:
+
+```ts
+import { createBetterTranslateReact } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export const { BetterTranslateProvider, useTranslations } =
+  createBetterTranslateReact(translator);
+```
+
+Then import the app-local provider and hook instead of the package-level ones.
+
+## 5. Read translations inside a component
 
 Create `src/header.tsx`:
 
 ```tsx
-import { useTranslations } from "@better-translate/react";
-
-import { translator } from "./i18n";
-
-export function Header() {
-  const { locale, setLocale, t } = useTranslations<typeof translator>();
-
-  return (
-    <header>
-      <h1>{t("home.title")}</h1>
-      <button onClick={() => setLocale("en")} disabled={locale === "en"}>
-        English
-      </button>
-      <button onClick={() => setLocale("es")} disabled={locale === "es"}>
-        Espanol
-      </button>
-    </header>
-  );
-}
-```
-
-## Optional: type `useTranslations()` once for the whole app
-
-If you want plain `useTranslations()` to autocomplete your translation keys without
-repeating `<typeof translator>` in every component, add one declaration file:
-
-Create `src/better-translate.d.ts`:
-
-```ts
-import { translator } from "./i18n";
-
-declare module "@better-translate/react" {
-  interface BetterTranslateReactTypes {
-    translator: typeof translator;
-  }
-}
-```
-
-Then your components can call the hook without a generic:
-
-```tsx
-import { useTranslations } from "@better-translate/react";
+import { useTranslations } from "./i18n";
 
 export function Header() {
   const { locale, setLocale, t } = useTranslations();
@@ -128,7 +103,32 @@ export function Header() {
 ```
 
 Explicit generics still work, so you can keep using `useTranslations<typeof translator>()`
-where that fits your codebase better.
+where that fits your codebase better:
+
+```tsx
+import { useTranslations } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export function Header() {
+  const { t } = useTranslations<typeof translator>();
+
+  return <h1>{t("home.title")}</h1>;
+}
+```
+
+If you prefer to keep importing directly from `@better-translate/react`, module
+augmentation is still supported:
+
+```ts
+import { translator } from "./i18n";
+
+declare module "@better-translate/react" {
+  interface BetterTranslateReactTypes {
+    translator: typeof translator;
+  }
+}
+```
 
 ## When to use React only
 

--- a/examples/react-vite-example/src/app.test.tsx
+++ b/examples/react-vite-example/src/app.test.tsx
@@ -4,9 +4,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { useTranslations } from "@better-translate/react";
-
-import type { AppTranslator } from "./i18n.ts";
+import { useTranslations } from "./i18n.ts";
 import { renderApp } from "./test/render-app.tsx";
 
 class TestErrorBoundary extends Component<
@@ -138,7 +136,7 @@ describe("react-vite-example", () => {
     let capturedError: unknown;
 
     function Consumer() {
-      useTranslations<AppTranslator>();
+      useTranslations();
       return null;
     }
 

--- a/examples/react-vite-example/src/components/greeting-panel.tsx
+++ b/examples/react-vite-example/src/components/greeting-panel.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
 
-import { useTranslations } from "@better-translate/react";
+import { useTranslations } from "../i18n.ts";
 
 import { DemoPanel } from "./demo-panel.tsx";
-import type { AppTranslator } from "../i18n.ts";
 
 export function GreetingPanel() {
-  const { t } = useTranslations<AppTranslator>();
+  const { t } = useTranslations();
   const [salute, setSalute] = useState("Dr.");
   const [name, setName] = useState("Ada");
 

--- a/examples/react-vite-example/src/components/header-panel.tsx
+++ b/examples/react-vite-example/src/components/header-panel.tsx
@@ -1,9 +1,7 @@
-import { useTranslations } from "@better-translate/react";
-
-import type { AppTranslator } from "../i18n.ts";
+import { useTranslations } from "../i18n.ts";
 
 export function HeaderPanel() {
-  const { t } = useTranslations<AppTranslator>();
+  const { t } = useTranslations();
 
   return (
     <section className="hero-panel">

--- a/examples/react-vite-example/src/components/locale-status-panel.tsx
+++ b/examples/react-vite-example/src/components/locale-status-panel.tsx
@@ -1,7 +1,6 @@
-import { useTranslations } from "@better-translate/react";
+import { useTranslations } from "../i18n.ts";
 
 import { DemoPanel } from "./demo-panel.tsx";
-import type { AppTranslator } from "../i18n.ts";
 
 export function LocaleStatusPanel() {
   const {
@@ -13,7 +12,7 @@ export function LocaleStatusPanel() {
     localeError,
     messages,
     t,
-  } = useTranslations<AppTranslator>();
+  } = useTranslations();
 
   const cachedLocales = Object.keys(messages).join(", ");
 

--- a/examples/react-vite-example/src/components/locale-switcher-panel.tsx
+++ b/examples/react-vite-example/src/components/locale-switcher-panel.tsx
@@ -1,7 +1,6 @@
-import { useTranslations } from "@better-translate/react";
+import { useTranslations } from "../i18n.ts";
 
 import { DemoPanel } from "./demo-panel.tsx";
-import type { AppTranslator } from "../i18n.ts";
 
 const ACTION_LABELS = {
   en: "actions.switchToEnglish",
@@ -17,7 +16,7 @@ export function LocaleSwitcherPanel() {
     setLocale,
     supportedLocales,
     t,
-  } = useTranslations<AppTranslator>();
+  } = useTranslations();
 
   return (
     <DemoPanel

--- a/examples/react-vite-example/src/components/messages-panel.tsx
+++ b/examples/react-vite-example/src/components/messages-panel.tsx
@@ -1,10 +1,9 @@
-import { useTranslations } from "@better-translate/react";
+import { useTranslations } from "../i18n.ts";
 
 import { DemoPanel } from "./demo-panel.tsx";
-import type { AppTranslator } from "../i18n.ts";
 
 export function MessagesPanel() {
-  const { locale, messages, t } = useTranslations<AppTranslator>();
+  const { locale, messages, t } = useTranslations();
   const hasFrench = Object.prototype.hasOwnProperty.call(messages, "fr");
 
   return (

--- a/examples/react-vite-example/src/components/site-header.tsx
+++ b/examples/react-vite-example/src/components/site-header.tsx
@@ -1,12 +1,10 @@
-import { useTranslations } from "@better-translate/react";
-
-import type { AppTranslator } from "../i18n.ts";
+import { useTranslations } from "../i18n.ts";
 
 const FLAG: Record<string, string> = { en: "EN", es: "ES", fr: "FR" };
 
 export function SiteHeader() {
   const { locale, setLocale, supportedLocales, isLoadingLocale } =
-    useTranslations<AppTranslator>();
+    useTranslations();
   return (
     <header className="site-header">
       <div className="site-header__inner">

--- a/examples/react-vite-example/src/i18n.ts
+++ b/examples/react-vite-example/src/i18n.ts
@@ -1,4 +1,5 @@
 import { configureTranslations } from "@better-translate/core";
+import { createBetterTranslateReact } from "@better-translate/react";
 
 function wait(ms: number) {
   return new Promise((resolve) => {
@@ -144,6 +145,11 @@ export function createTranslator() {
   });
 }
 
+export const translator = await createTranslator();
+
+export const { BetterTranslateProvider, useTranslations } =
+  createBetterTranslateReact(translator);
+
 export function createFailingTranslator() {
   return configureTranslations({
     availableLocales: ["en", "fr"] as const,
@@ -159,7 +165,7 @@ export function createFailingTranslator() {
   });
 }
 
-export type AppTranslator = Awaited<ReturnType<typeof createTranslator>>;
+export type AppTranslator = typeof translator;
 export type FailureTranslator = Awaited<
   ReturnType<typeof createFailingTranslator>
 >;

--- a/examples/react-vite-example/src/main.tsx
+++ b/examples/react-vite-example/src/main.tsx
@@ -1,21 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-import { BetterTranslateProvider } from "@better-translate/react";
-
 import App from "./App.tsx";
-import { createFailingTranslator, createTranslator } from "./i18n.ts";
+import { BetterTranslateProvider, createFailingTranslator } from "./i18n.ts";
 import "./index.css";
 
 async function bootstrap() {
-  const [translator, failureTranslator] = await Promise.all([
-    createTranslator(),
-    createFailingTranslator(),
-  ]);
+  const failureTranslator = await createFailingTranslator();
 
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
-      <BetterTranslateProvider translator={translator}>
+      <BetterTranslateProvider>
         <App failureTranslator={failureTranslator} />
       </BetterTranslateProvider>
     </StrictMode>,

--- a/examples/react-vite-example/src/test/render-app.tsx
+++ b/examples/react-vite-example/src/test/render-app.tsx
@@ -1,8 +1,7 @@
 import { render } from "@testing-library/react";
 
-import { BetterTranslateProvider } from "@better-translate/react";
-
 import {
+  BetterTranslateProvider,
   createFailingTranslator,
   createTranslator,
   type AppTranslator,

--- a/examples/react-vite-example/tsconfig.app.json
+++ b/examples/react-vite-example/tsconfig.app.json
@@ -10,6 +10,11 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@better-translate/core": ["../../packages/core/dist/index.d.ts"],
+      "@better-translate/react": ["../../packages/react/dist/index.d.ts"]
+    },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",

--- a/examples/react-vite-example/vite.config.ts
+++ b/examples/react-vite-example/vite.config.ts
@@ -8,6 +8,18 @@ import { defineConfig } from "vite";
 
 const config = {
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@better-translate/core": path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../packages/core/dist/index.js",
+      ),
+      "@better-translate/react": path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../packages/react/dist/index.js",
+      ),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,6 +62,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 If you want `useTranslations()` to autocomplete keys and locales without
 repeating generics or adding a declaration file, bind your translator once:
 
+Create `src/i18n-react.ts`:
+
 ```ts
 import { createBetterTranslateReact } from "@better-translate/react";
 
@@ -71,14 +73,30 @@ export const { BetterTranslateProvider, useTranslations } =
   createBetterTranslateReact(translator);
 ```
 
-Then import the app-local provider and hook instead of the package-level ones.
+Then update `src/main.tsx` to import the app-local provider:
+
+```tsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import { App } from "./app";
+import { BetterTranslateProvider } from "./i18n-react";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BetterTranslateProvider>
+      <App />
+    </BetterTranslateProvider>
+  </React.StrictMode>,
+);
+```
 
 ## 5. Read translations inside a component
 
 Create `src/header.tsx`:
 
 ```tsx
-import { useTranslations } from "./i18n";
+import { useTranslations } from "./i18n-react";
 
 export function Header() {
   const { locale, setLocale, t } = useTranslations();

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,17 +57,31 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 ```
 
-## 4. Read translations inside a component
+## 4. Create a typed provider + hook pair
+
+If you want `useTranslations()` to autocomplete keys and locales without
+repeating generics or adding a declaration file, bind your translator once:
+
+```ts
+import { createBetterTranslateReact } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export const { BetterTranslateProvider, useTranslations } =
+  createBetterTranslateReact(translator);
+```
+
+Then import the app-local provider and hook instead of the package-level ones.
+
+## 5. Read translations inside a component
 
 Create `src/header.tsx`:
 
 ```tsx
-import { useTranslations } from "@better-translate/react";
-
-import { translator } from "./i18n";
+import { useTranslations } from "./i18n";
 
 export function Header() {
-  const { locale, setLocale, t } = useTranslations<typeof translator>();
+  const { locale, setLocale, t } = useTranslations();
 
   return (
     <header>
@@ -80,6 +94,33 @@ export function Header() {
       </button>
     </header>
   );
+}
+```
+
+If you prefer, the package still supports explicit generics:
+
+```tsx
+import { useTranslations } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export function Header() {
+  const { t } = useTranslations<typeof translator>();
+
+  return <h1>{t("home.title")}</h1>;
+}
+```
+
+You can also use module augmentation if you want to keep importing
+`useTranslations()` directly from `@better-translate/react`:
+
+```ts
+import { translator } from "./i18n";
+
+declare module "@better-translate/react" {
+  interface BetterTranslateReactTypes {
+    translator: typeof translator;
+  }
 }
 ```
 

--- a/packages/react/src/create-better-translate-react.tsx
+++ b/packages/react/src/create-better-translate-react.tsx
@@ -1,0 +1,39 @@
+import { BetterTranslateProvider as BaseBetterTranslateProvider } from "./provider.js";
+import type {
+  AnyBetterTranslateTranslator,
+  CreateBetterTranslateReactResult,
+  TypedBetterTranslateProviderProps,
+} from "./types.js";
+import { useTranslations as useBaseTranslations } from "./use-translations.js";
+
+/**
+ * Binds a translator to a provider/hook pair so app code gets typed
+ * `useTranslations()` without repeating generics or adding module augmentation.
+ */
+export function createBetterTranslateReact<
+  TTranslator extends AnyBetterTranslateTranslator,
+>(translator: TTranslator): CreateBetterTranslateReactResult<TTranslator> {
+  function BetterTranslateProvider({
+    children,
+    initialLocale,
+    translator: overrideTranslator,
+  }: TypedBetterTranslateProviderProps<TTranslator>) {
+    return (
+      <BaseBetterTranslateProvider
+        initialLocale={initialLocale}
+        translator={overrideTranslator ?? translator}
+      >
+        {children}
+      </BaseBetterTranslateProvider>
+    );
+  }
+
+  function useTranslations() {
+    return useBaseTranslations<TTranslator>();
+  }
+
+  return {
+    BetterTranslateProvider,
+    useTranslations,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+export { createBetterTranslateReact } from "./create-better-translate-react.js";
 export { BetterTranslateProvider } from "./provider.js";
 export { useTranslations } from "./use-translations.js";
 
@@ -5,8 +6,10 @@ export type {
   AnyBetterTranslateTranslator,
   BetterTranslateProviderProps,
   BetterTranslateReactTypes,
+  CreateBetterTranslateReactResult,
   DefaultBetterTranslateTranslator,
   InferLocale,
   InferMessages,
+  TypedBetterTranslateProviderProps,
   UseTranslationsValue,
 } from "./types.js";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -47,6 +47,14 @@ export interface BetterTranslateProviderProps<
   translator: TTranslator;
 }
 
+export interface TypedBetterTranslateProviderProps<
+  TTranslator extends AnyBetterTranslateTranslator,
+> {
+  children: ReactNode;
+  initialLocale?: InferLocale<TTranslator>;
+  translator?: TTranslator;
+}
+
 export interface UseTranslationsValue<
   TTranslator extends AnyBetterTranslateTranslator,
 > {
@@ -80,3 +88,12 @@ export interface UseTranslationsValue<
 
 export type AnyUseTranslationsValue =
   UseTranslationsValue<AnyBetterTranslateTranslator>;
+
+export interface CreateBetterTranslateReactResult<
+  TTranslator extends AnyBetterTranslateTranslator,
+> {
+  BetterTranslateProvider(
+    props: TypedBetterTranslateProviderProps<TTranslator>,
+  ): ReactNode;
+  useTranslations(): UseTranslationsValue<TTranslator>;
+}

--- a/packages/react/tests/runtime/react.test.tsx
+++ b/packages/react/tests/runtime/react.test.tsx
@@ -4,6 +4,7 @@ import { create } from "react-test-renderer";
 
 import { configureTranslations } from "@better-translate/core";
 
+import { createBetterTranslateReact } from "../../src/create-better-translate-react.js";
 import { BetterTranslateProvider } from "../../src/provider.js";
 import { useTranslations } from "../../src/use-translations.js";
 
@@ -192,6 +193,39 @@ describe("@better-translate/react", () => {
     });
 
     expect(latestValue?.locale).toBe("en");
+    expect(latestValue?.t("common.hello")).toBe("Hello");
+  });
+
+  it("creates a typed provider and hook pair from a translator", async () => {
+    const translator = await configureTranslations({
+      availableLocales: ["en", "es"] as const,
+      defaultLocale: "en",
+      fallbackLocale: "en",
+      messages: { en, es },
+    });
+
+    const {
+      BetterTranslateProvider: TypedBetterTranslateProvider,
+      useTranslations: useTypedTranslations,
+    } = createBetterTranslateReact(translator);
+
+    let latestValue: ReturnType<typeof useTypedTranslations> | undefined;
+
+    function Consumer() {
+      latestValue = useTypedTranslations();
+      return null;
+    }
+
+    await act(async () => {
+      create(
+        <TypedBetterTranslateProvider>
+          <Consumer />
+        </TypedBetterTranslateProvider>,
+      );
+    });
+
+    expect(latestValue?.locale).toBe("en");
+    expect(latestValue?.supportedLocales).toEqual(["en", "es"]);
     expect(latestValue?.t("common.hello")).toBe("Hello");
   });
 

--- a/packages/react/tests/types/react.typecheck.tsx
+++ b/packages/react/tests/types/react.typecheck.tsx
@@ -1,6 +1,10 @@
 import { configureTranslations } from "@better-translate/core";
 
-import { BetterTranslateProvider, useTranslations } from "../../dist/index.js";
+import {
+  BetterTranslateProvider,
+  createBetterTranslateReact,
+  useTranslations,
+} from "../../dist/index.js";
 
 const translator = await configureTranslations({
   availableLocales: ["en", "es", "fr"] as const,
@@ -182,6 +186,32 @@ function AugmentedConsumer() {
   return null;
 }
 
+const {
+  BetterTranslateProvider: TypedBetterTranslateProvider,
+  useTranslations: useTypedTranslations,
+} = createBetterTranslateReact(translator);
+
+function FactoryConsumer() {
+  const translations = useTypedTranslations();
+
+  translations.t("common.hello");
+  translations.t("account.balance.label");
+  void translations.setLocale("es");
+  void translations.loadLocale("fr");
+  translations.availableLanguages[0]?.locale;
+  translations.messages.en;
+  translations.messages.fr;
+  translations.supportedLocales[0];
+
+  // @ts-expect-error invalid translation key should fail
+  translations.t("account.balance.total");
+
+  // @ts-expect-error unsupported locale should fail
+  void translations.setLocale("pt");
+
+  return null;
+}
+
 <BetterTranslateProvider translator={translator}>
   <Consumer />
 </BetterTranslateProvider>;
@@ -189,6 +219,23 @@ function AugmentedConsumer() {
 <BetterTranslateProvider translator={translator}>
   <AugmentedConsumer />
 </BetterTranslateProvider>;
+
+<TypedBetterTranslateProvider>
+  <FactoryConsumer />
+</TypedBetterTranslateProvider>;
+
+<TypedBetterTranslateProvider initialLocale="es">
+  <FactoryConsumer />
+</TypedBetterTranslateProvider>;
+
+<TypedBetterTranslateProvider translator={translator}>
+  <FactoryConsumer />
+</TypedBetterTranslateProvider>;
+
+// @ts-expect-error initialLocale must be a supported locale
+<TypedBetterTranslateProvider initialLocale="pt">
+  <FactoryConsumer />
+</TypedBetterTranslateProvider>;
 
 <BetterTranslateProvider translator={translator} initialLocale="es">
   <Consumer />

--- a/skills/expo/SKILL.md
+++ b/skills/expo/SKILL.md
@@ -22,9 +22,35 @@ There is no separate native adapter package.
 
 ## Keep TypeScript autocomplete available
 
-Both React typing patterns work in Expo too.
+The simplest no-extra-generic setup is to bind the translator once and export an
+app-local provider + hook pair.
 
-### Pattern 1: explicit generic
+### Pattern 1: `createBetterTranslateReact(translator)`
+
+```ts
+import { createBetterTranslateReact } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export const { BetterTranslateProvider, useTranslations } =
+  createBetterTranslateReact(translator);
+```
+
+Then screens can import your app-local hook:
+
+```tsx
+import { useTranslations } from "./i18n";
+
+export function HomeScreen() {
+  const { t } = useTranslations();
+
+  return <Text>{t("home.title")}</Text>;
+}
+```
+
+These fallback patterns still work in Expo too.
+
+### Pattern 2: explicit generic
 
 ```tsx
 import { useTranslations } from "@better-translate/react";
@@ -38,7 +64,7 @@ export function HomeScreen() {
 }
 ```
 
-### Pattern 2: module augmentation for zero-arg `useTranslations()`
+### Pattern 3: module augmentation for zero-arg `useTranslations()`
 
 Create `src/better-translate.d.ts`:
 

--- a/skills/react/SKILL.md
+++ b/skills/react/SKILL.md
@@ -34,9 +34,35 @@ export function Root() {
 
 ## Keep TypeScript autocomplete available
 
-Both of these patterns are supported.
+The simplest no-extra-generic setup is to bind the translator once and export an
+app-local provider + hook pair.
 
-### Pattern 1: explicit generic
+### Pattern 1: `createBetterTranslateReact(translator)`
+
+```ts
+import { createBetterTranslateReact } from "@better-translate/react";
+
+import { translator } from "./i18n";
+
+export const { BetterTranslateProvider, useTranslations } =
+  createBetterTranslateReact(translator);
+```
+
+Then import your app-local `useTranslations` instead of importing the package hook directly:
+
+```tsx
+import { useTranslations } from "./i18n";
+
+export function Header() {
+  const { t } = useTranslations();
+
+  return <h1>{t("home.title")}</h1>;
+}
+```
+
+These fallback patterns are still supported too.
+
+### Pattern 2: explicit generic
 
 ```tsx
 import { useTranslations } from "@better-translate/react";
@@ -57,7 +83,7 @@ export function Header() {
 }
 ```
 
-### Pattern 2: module augmentation for zero-arg `useTranslations()`
+### Pattern 3: module augmentation for zero-arg `useTranslations()`
 
 Create `src/better-translate.d.ts`:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `createBetterTranslateReact(translator)` to `@better-translate/react` to generate a typed `BetterTranslateProvider` and zero‑arg `useTranslations()` bound to your translator. Updates the React README, docs, and the Vite example to use the factory-first pattern, addressing the Linear issue where autocomplete required explicit types.

- **New Features**
  - `createBetterTranslateReact(translator)` returns `{ BetterTranslateProvider, useTranslations }`, both typed to your translator.
  - `BetterTranslateProvider` supports `initialLocale` and an optional `translator` override.
  - React README/docs show the factory-first flow plus alternatives (explicit generics and module augmentation).
  - Example app now imports app-local `useTranslations` and points to local `dist` for `@better-translate/core` and `@better-translate/react`; runtime/type tests added.

- **Migration**
  - In your i18n module: `export const { BetterTranslateProvider, useTranslations } = createBetterTranslateReact(translator)`.
  - Wrap your app with the new `BetterTranslateProvider` (no `translator` prop needed) and import `useTranslations()` from your i18n module.
  - No breaking changes; existing generic-based or module-augmented usage still works.

<sup>Written for commit 656b5386b454e41e9cd0ead72c8af46ee031324a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

