### PR TITLE
Add optional locale support to core (#88)

### DIFF
--- a/.changeset/optional-locales-core.md
+++ b/.changeset/optional-locales-core.md
@@ -1,0 +1,5 @@
+---
+"@better-translate/core": minor
+---
+
+Add optional locale configuration for incomplete or unavailable translations in core.

--- a/apps/landing/components/landing-translations-provider.tsx
+++ b/apps/landing/components/landing-translations-provider.tsx
@@ -32,6 +32,9 @@ function createClientTranslator(
   const currentLocaleMessages: Record<string, LandingMessages> = {
     [locale]: messages,
   };
+  const optionalLocales = landingLocales.filter(
+    (availableLocale) => availableLocale !== locale,
+  );
   const configureClientTranslations = configureTranslations as unknown as (
     config: unknown,
   ) => Promise<LandingTranslator>;
@@ -42,6 +45,7 @@ function createClientTranslator(
     fallbackLocale: locale,
     directions: landingDirections,
     languages: landingLanguages,
+    optionalLocales,
     messages: currentLocaleMessages,
   });
 }

--- a/apps/landing/lib/i18n/config.ts
+++ b/apps/landing/lib/i18n/config.ts
@@ -14,6 +14,7 @@ import {
   landingDirections,
   landingLanguages,
   landingLocales,
+  landingOptionalLocales,
 } from "./shared";
 
 export {
@@ -23,6 +24,7 @@ export {
   landingDirections,
   landingLanguages,
   landingLocales,
+  landingOptionalLocales,
   type LandingLocale,
 } from "./shared";
 
@@ -39,12 +41,14 @@ export const config = {
   fallbackLocale: landingDefaultLocale,
   directions: landingDirections,
   languages: landingLanguages,
+  optionalLocales: landingOptionalLocales,
   messages: landingMessages,
 } satisfies TranslationConfigOptions<
   typeof landingLocales,
   typeof landingMessages,
   undefined,
-  typeof landingDefaultLocale
+  typeof landingDefaultLocale,
+  typeof landingOptionalLocales
 >;
 
 export type config = typeof config;

--- a/apps/landing/lib/i18n/shared.ts
+++ b/apps/landing/lib/i18n/shared.ts
@@ -8,7 +8,29 @@ export const landingLocales = ["en", "es", "ar", "ja"] as const;
 export type LandingLocale = (typeof landingLocales)[number];
 
 export const landingDefaultLocale = "en" as const;
-export const landingOptionalLocales = ["es", "ar", "ja"] as const;
+
+type TupleWithout<
+  TTuple extends readonly unknown[],
+  TExcluded,
+> = TTuple extends readonly [infer THead, ...infer TTail]
+  ? THead extends TExcluded
+    ? TupleWithout<TTail, TExcluded>
+    : readonly [THead, ...TupleWithout<TTail, TExcluded>]
+  : readonly [];
+
+function tupleWithout<
+  const TTuple extends readonly string[],
+  const TExcluded extends TTuple[number],
+>(items: TTuple, excluded: TExcluded) {
+  return items.filter(
+    (item): item is Exclude<TTuple[number], TExcluded> => item !== excluded,
+  ) as unknown as TupleWithout<TTuple, TExcluded>;
+}
+
+export const landingOptionalLocales = tupleWithout(
+  landingLocales,
+  landingDefaultLocale,
+);
 
 export const landingDirections: Partial<
   Record<LandingLocale, TranslationDirection>

--- a/apps/landing/lib/i18n/shared.ts
+++ b/apps/landing/lib/i18n/shared.ts
@@ -8,6 +8,7 @@ export const landingLocales = ["en", "es", "ar", "ja"] as const;
 export type LandingLocale = (typeof landingLocales)[number];
 
 export const landingDefaultLocale = "en" as const;
+export const landingOptionalLocales = ["es", "ar", "ja"] as const;
 
 export const landingDirections: Partial<
   Record<LandingLocale, TranslationDirection>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ export const translator = await configureTranslations({
   languages: [
     {
       locale: "es",
-      nativeLabel: "Espanol",
+      nativeLabel: "Español",
       optional: true,
       shortLabel: "ES",
     },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -79,6 +79,61 @@ If the fallback doesn't have it either, it returns the key string itself.
 - Missing locale value -> fallback locale value
 - Missing fallback value -> key string
 
+## Optional locales
+
+By default, every locale in `availableLocales` must either have messages or an
+async loader. Preloaded locale messages are type-checked against the default
+locale so missing keys fail during TypeScript checks.
+
+If a locale is intentionally incomplete, mark it optional:
+
+```ts
+export const translator = await configureTranslations({
+  availableLocales: ["en", "es", "fr"] as const,
+  defaultLocale: "en",
+  fallbackLocale: "en",
+  optionalLocales: ["fr"],
+  messages: {
+    en,
+    es,
+    fr: {
+      home: {
+        title: "Bonjour",
+      },
+    },
+  },
+});
+```
+
+Optional locales may be omitted from `messages` and `loaders`, or may provide a
+partial message tree. Missing keys use the configured fallback locale at
+runtime.
+
+You can also mark a locale optional in its language metadata when the locale has
+no preloaded messages or loader yet:
+
+```ts
+export const translator = await configureTranslations({
+  availableLocales: ["en", "es"] as const,
+  defaultLocale: "en",
+  fallbackLocale: "en",
+  languages: [
+    {
+      locale: "es",
+      nativeLabel: "Espanol",
+      optional: true,
+      shortLabel: "ES",
+    },
+  ],
+  messages: { en },
+});
+```
+
+Use `optionalLocales` when you provide a partial message object and want
+TypeScript to allow missing nested keys. Do not mark the default locale
+optional. The default locale remains the source for translation key and
+placeholder inference.
+
 ## Async loaders
 
 Register locale loaders for languages you don't want to preload. Loaded locales are cached after the first successful load.

--- a/packages/core/src/core.d.ts
+++ b/packages/core/src/core.d.ts
@@ -11,8 +11,8 @@ import type {
   TranslateOptions,
   TranslationConfigOptions,
   TranslationHelpers,
-  TranslationLanguageMetadata,
   TranslationJsonSchema,
+  TranslationLanguageMetadata,
   TranslationLoader,
   TranslationMessages,
 } from "./types.js";
@@ -82,25 +82,18 @@ export declare function configureTranslations<
     | Partial<Record<TLocales[number], TranslationLoader<unknown>>>
     | undefined = undefined,
   const TDefaultLocale extends TLocales[number] = TLocales[number],
+  const TOptionalLocales extends
+    | readonly TLocales[number][]
+    | undefined = undefined,
 >(
   config: TranslationConfigOptions<
     TLocales,
     TMessages,
     TLoaders,
-    TDefaultLocale
+    TDefaultLocale,
+    TOptionalLocales
   >,
 ): Promise<OptionsFormTranslator<TLocales, TMessages, TDefaultLocale>>;
-
-export declare function configureTranslations(
-  config:
-    | Record<string, TranslationMessages>
-    | TranslationConfigOptions<
-        readonly string[],
-        Partial<Record<string, TranslationMessages>>,
-        Partial<Record<string, TranslationLoader<unknown>>> | undefined,
-        string
-      >,
-): Promise<AnyConfiguredTranslator>;
 
 export declare function createTranslationHelpers<
   TLocale extends string,
@@ -117,7 +110,7 @@ export declare function createTranslationHelpers<
   TranslationHelpers<
     Extract<keyof TMessages, string>,
     ShortFormTranslator<TMessages> extends ConfiguredTranslator<
-      any,
+      string,
       infer TSourceMessages
     >
       ? TSourceMessages
@@ -134,12 +127,16 @@ export declare function createTranslationHelpers<
     | Partial<Record<TLocales[number], TranslationLoader<unknown>>>
     | undefined = undefined,
   const TDefaultLocale extends TLocales[number] = TLocales[number],
+  const TOptionalLocales extends
+    | readonly TLocales[number][]
+    | undefined = undefined,
 >(
   config: TranslationConfigOptions<
     TLocales,
     TMessages,
     TLoaders,
-    TDefaultLocale
+    TDefaultLocale,
+    TOptionalLocales
   >,
 ): Promise<
   TranslationHelpers<

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,10 +1,10 @@
-import { createTranslationJsonSchema } from "./create-translation-json-schema.js";
 import { createConfiguredTranslator } from "./create-configured-translator.js";
+import { createTranslationJsonSchema } from "./create-translation-json-schema.js";
 import { getGlobalStore } from "./global-store.js";
 import { normalizeConfig } from "./normalize-config.js";
 import type {
-  AnyTranslationHelpers,
   AnyConfiguredTranslator,
+  AnyTranslationHelpers,
   BtTranslateOptions,
   ConfiguredTranslator,
   OptionsFormTranslator,
@@ -12,9 +12,9 @@ import type {
   ShortFormTranslator,
   StrictTranslationLocaleMap,
   TranslateOptions,
+  TranslationConfigOptions,
   TranslationHelpers,
   TranslationLanguageMetadata,
-  TranslationConfigOptions,
   TranslationLoader,
   TranslationMessages,
 } from "./types.js";
@@ -96,12 +96,16 @@ export async function configureTranslations<
     | Partial<Record<TLocales[number], TranslationLoader<unknown>>>
     | undefined = undefined,
   const TDefaultLocale extends TLocales[number] = TLocales[number],
+  const TOptionalLocales extends
+    | readonly TLocales[number][]
+    | undefined = undefined,
 >(
   config: TranslationConfigOptions<
     TLocales,
     TMessages,
     TLoaders,
-    TDefaultLocale
+    TDefaultLocale,
+    TOptionalLocales
   >,
 ): Promise<OptionsFormTranslator<TLocales, TMessages, TDefaultLocale>>;
 
@@ -140,7 +144,7 @@ export function createTranslationHelpers<
   TranslationHelpers<
     Extract<keyof TMessages, string>,
     ShortFormTranslator<TMessages> extends ConfiguredTranslator<
-      any,
+      string,
       infer TSourceMessages
     >
       ? TSourceMessages
@@ -156,12 +160,16 @@ export function createTranslationHelpers<
     | Partial<Record<TLocales[number], TranslationLoader<unknown>>>
     | undefined = undefined,
   const TDefaultLocale extends TLocales[number] = TLocales[number],
+  const TOptionalLocales extends
+    | readonly TLocales[number][]
+    | undefined = undefined,
 >(
   config: TranslationConfigOptions<
     TLocales,
     TMessages,
     TLoaders,
-    TDefaultLocale
+    TDefaultLocale,
+    TOptionalLocales
   >,
 ): Promise<
   TranslationHelpers<
@@ -203,7 +211,11 @@ export function createTranslationHelpers(
     };
   }
 
-  return configureTranslations(input).then((translator) =>
+  const configureRuntimeTranslations = configureTranslations as (
+    config: RuntimeConfigInput,
+  ) => Promise<AnyConfiguredTranslator>;
+
+  return configureRuntimeTranslations(input).then((translator) =>
     createTranslationHelpers(translator),
   );
 }

--- a/packages/core/src/normalize-config.ts
+++ b/packages/core/src/normalize-config.ts
@@ -63,12 +63,55 @@ function createNormalizedLanguages(
   return normalizedLanguages;
 }
 
+function createOptionalLocaleSet(
+  locales: readonly string[],
+  defaultLocale: string,
+  languages?: readonly TranslationLanguageMetadata<string>[],
+  optionalLocales?: readonly string[],
+): Set<string> {
+  const supportedLocaleSet = new Set(locales);
+  const optionalLocaleSet = new Set<string>();
+
+  for (const locale of optionalLocales ?? []) {
+    if (!supportedLocaleSet.has(locale)) {
+      throw new Error(
+        `The locale "${locale}" is present in optionalLocales but not in availableLocales.`,
+      );
+    }
+
+    if (locale === defaultLocale) {
+      throw new Error(
+        `The default locale "${locale}" cannot be marked as optional.`,
+      );
+    }
+
+    optionalLocaleSet.add(locale);
+  }
+
+  for (const language of languages ?? []) {
+    if (language.optional !== true) {
+      continue;
+    }
+
+    if (language.locale === defaultLocale) {
+      throw new Error(
+        `The default locale "${language.locale}" cannot be marked as optional.`,
+      );
+    }
+
+    optionalLocaleSet.add(language.locale);
+  }
+
+  return optionalLocaleSet;
+}
+
 /**
  * Normalizes either supported configuration form into one internal runtime
  * shape used by the translator implementation.
  *
- * It also validates locale declarations, required source messages, and that
- * message/loader locales are included in `availableLocales`.
+ * It also validates locale declarations, required source messages, optional
+ * locale declarations, and that message/loader locales are included in
+ * `availableLocales`.
  */
 export function normalizeConfig(
   input: RuntimeConfigInput,
@@ -82,7 +125,7 @@ export function normalizeConfig(
       );
     }
 
-    const defaultLocale = locales[0]!;
+    const [defaultLocale] = locales as [string, ...string[]];
 
     return {
       defaultLocale,
@@ -122,6 +165,13 @@ export function normalizeConfig(
     );
   }
 
+  const optionalLocaleSet = createOptionalLocaleSet(
+    supportedLocales,
+    input.defaultLocale,
+    input.languages,
+    input.optionalLocales,
+  );
+
   for (const locale of Object.keys(input.messages)) {
     if (!supportedLocales.includes(locale)) {
       throw new Error(
@@ -144,6 +194,25 @@ export function normalizeConfig(
         `The locale "${locale}" is present in directions but not in availableLocales.`,
       );
     }
+  }
+
+  const configuredLocales = new Set([
+    ...Object.keys(input.messages),
+    ...Object.keys(input.loaders ?? {}),
+  ]);
+
+  for (const locale of supportedLocales) {
+    if (
+      locale === input.defaultLocale ||
+      optionalLocaleSet.has(locale) ||
+      configuredLocales.has(locale)
+    ) {
+      continue;
+    }
+
+    throw new Error(
+      `Missing messages or loader for locale "${locale}". Mark it optional with optionalLocales if translations are intentionally unavailable.`,
+    );
   }
 
   return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,6 +92,33 @@ type ExactMessageShape<
   ? TCandidate
   : never;
 
+type IsPartialMessageShape<TReference, TCandidate> = [TCandidate] extends [
+  string,
+]
+  ? [TReference] extends [string]
+    ? true
+    : false
+  : [TCandidate] extends [TranslationMessages]
+    ? [TReference] extends [TranslationMessages]
+      ? Exclude<keyof TCandidate, keyof TReference> extends never
+        ? AllTrue<
+            {
+              [K in keyof TCandidate]: K extends keyof TReference
+                ? IsPartialMessageShape<TReference[K], TCandidate[K]>
+                : false;
+            }[keyof TCandidate]
+          >
+        : false
+      : false
+    : false;
+
+type PartialMessageShape<
+  TReference,
+  TCandidate extends TranslationMessages,
+> = IsPartialMessageShape<TReference, TCandidate> extends true
+  ? TCandidate
+  : never;
+
 type EnforceLocaleMapShapeParity<
   TMessages extends Record<string, TranslationMessages>,
 > = {
@@ -110,24 +137,38 @@ type EnforceLocaleMapShapeParity<
 type EnforceReferenceMessageShape<
   TMessages extends Partial<Record<string, TranslationMessages>>,
   TReference extends TranslationMessages,
+  TDefaultLocale extends string,
+  TOptionalLocale extends PropertyKey = never,
 > = {
   [TLocale in keyof TMessages]: TMessages[TLocale] extends TranslationMessages
-    ? ExactMessageShape<DeepStringify<TReference>, TMessages[TLocale]>
+    ? TLocale extends TDefaultLocale
+      ? ExactMessageShape<DeepStringify<TReference>, TMessages[TLocale]>
+      : TLocale extends TOptionalLocale
+        ? PartialMessageShape<DeepStringify<TReference>, TMessages[TLocale]>
+        : ExactMessageShape<DeepStringify<TReference>, TMessages[TLocale]>
     : never;
 };
 
 type StrictOptionsMessages<
   TMessages extends Partial<Record<string, TranslationMessages>>,
   TDefaultLocale extends string,
+  TOptionalLocale extends PropertyKey = never,
 > = TMessages[TDefaultLocale] extends TranslationMessages
   ? Simplify<
       TMessages &
         EnforceReferenceMessageShape<
           TMessages,
-          Extract<TMessages[TDefaultLocale], TranslationMessages>
+          Extract<TMessages[TDefaultLocale], TranslationMessages>,
+          TDefaultLocale,
+          TOptionalLocale
         >
     >
   : never;
+
+type OptionalLocalesFromList<TOptionalLocales> =
+  TOptionalLocales extends readonly (infer TLocale extends string)[]
+    ? TLocale
+    : never;
 
 export type TranslationKey<TMessages extends TranslationMessages> =
   string extends keyof TMessages ? string : DotKeys<TMessages>;
@@ -147,6 +188,13 @@ export interface TranslationLanguageMetadata<TLocale extends string> {
   icon?: string;
   locale: TLocale;
   nativeLabel: string;
+  /**
+   * Marks this locale as optional.
+   *
+   * Optional locales may omit some or all translations and will fall back to
+   * the configured fallback locale at runtime.
+   */
+  optional?: boolean;
   shortLabel: string;
 }
 
@@ -430,13 +478,25 @@ export type TranslationConfigOptions<
     | Partial<Record<TLocales[number], TranslationLoader<unknown>>>
     | undefined = undefined,
   TDefaultLocale extends TLocales[number] = TLocales[number],
+  TOptionalLocales extends readonly TLocales[number][] | undefined = undefined,
 > = {
   availableLocales: TLocales;
   defaultLocale: TDefaultLocale;
   fallbackLocale?: TLocales[number];
   directions?: Partial<Record<TLocales[number], TranslationDirection>>;
+  /**
+   * Locales that are intentionally incomplete or unavailable.
+   *
+   * Optional locales may be omitted from `messages`/`loaders`, or may provide a
+   * partial message tree. Missing keys fall back to `fallbackLocale` at runtime.
+   */
+  optionalLocales?: TOptionalLocales;
   languages?: readonly TranslationLanguageMetadata<TLocales[number]>[];
-  messages: StrictOptionsMessages<TMessages, TDefaultLocale>;
+  messages: StrictOptionsMessages<
+    TMessages,
+    TDefaultLocale,
+    OptionalLocalesFromList<TOptionalLocales>
+  >;
   loaders?: TLoaders;
 };
 
@@ -459,14 +519,20 @@ export type InternalTranslationMessages = {
   readonly [key: string]: InternalTranslationNode;
 };
 
+export interface RuntimeTranslationConfigOptions {
+  availableLocales: readonly string[];
+  defaultLocale: string;
+  fallbackLocale?: string;
+  directions?: Partial<Record<string, TranslationDirection>>;
+  optionalLocales?: readonly string[];
+  languages?: readonly TranslationLanguageMetadata<string>[];
+  messages: Partial<Record<string, TranslationMessages>>;
+  loaders?: Partial<Record<string, TranslationLoader<unknown>>>;
+}
+
 export type RuntimeConfigInput =
   | Record<string, TranslationMessages>
-  | TranslationConfigOptions<
-      readonly string[],
-      Partial<Record<string, TranslationMessages>>,
-      Partial<Record<string, TranslationLoader<unknown>>> | undefined,
-      string
-    >;
+  | RuntimeTranslationConfigOptions;
 
 export interface InternalNormalizedConfig {
   defaultLocale: string;

--- a/packages/core/tests/runtime/core.test.ts
+++ b/packages/core/tests/runtime/core.test.ts
@@ -134,6 +134,51 @@ describe("better-translate core", () => {
     );
   });
 
+  it("allows optional locales to be partially translated or omitted", async () => {
+    const translator = await configureTranslations({
+      availableLocales: ["en", "es", "ja"] as const,
+      defaultLocale: "en",
+      fallbackLocale: "en",
+      optionalLocales: ["es"],
+      languages: [
+        {
+          ...jaLanguage,
+          optional: true,
+        },
+      ],
+      messages: {
+        en,
+        es: {
+          common: {
+            hello: "Hola",
+          },
+        },
+      },
+    });
+
+    expect(translator.getSupportedLocales()).toEqual(["en", "es", "ja"]);
+    expect(translator.t("common.hello", { locale: "es" })).toBe("Hola");
+    expect(translator.t("common.goodbye", { locale: "es" })).toBe("Goodbye");
+    expect(translator.t("common.hello", { locale: "ja" })).toBe("Hello");
+    expect(await translator.loadLocale("ja")).toBeUndefined();
+    expect(translator.getAvailableLanguages()).toEqual([
+      {
+        ...jaLanguage,
+        optional: true,
+      },
+      {
+        locale: "en",
+        nativeLabel: "en",
+        shortLabel: "EN",
+      },
+      {
+        locale: "es",
+        nativeLabel: "es",
+        shortLabel: "ES",
+      },
+    ]);
+  });
+
   it("defaults locale directions to ltr when directions are omitted", async () => {
     const translator = await configureTranslations({
       availableLocales: ["en", "es"] as const,
@@ -370,6 +415,7 @@ describe("better-translate core", () => {
         es: "rtl",
       },
       languages: [jaLanguage],
+      optionalLocales: ["ja"],
       messages: { en, es },
     });
 
@@ -470,8 +516,14 @@ describe("better-translate core", () => {
         shortLabel: "ES",
       });
     }).toThrow();
+    const firstLanguage = languages[0];
+    expect(firstLanguage).toBeDefined();
     expect(() => {
-      languages[0]!.nativeLabel = "Japanese";
+      if (!firstLanguage) {
+        throw new Error("Expected at least one language.");
+      }
+
+      firstLanguage.nativeLabel = "Japanese";
     }).toThrow();
     expect(translator.getAvailableLanguages()).toEqual([
       jaLanguage,

--- a/packages/core/tests/runtime/internals.test.ts
+++ b/packages/core/tests/runtime/internals.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from "bun:test";
 
+import { SUPPORTED_LOCALE_ROUTE_SYNTAXES } from "../../src/core.js";
 import { createConfiguredTranslator } from "../../src/create-configured-translator.js";
 import { createTranslationJsonSchema } from "../../src/create-translation-json-schema.js";
 import { interpolateMessage } from "../../src/interpolate-message.js";
 import { normalizeConfig } from "../../src/normalize-config.js";
 import { resolveMessageValue } from "../../src/resolve-message-value.js";
-import { snapshotLanguages } from "../../src/snapshot-languages.js";
 import {
   getRequestLocale,
   resolveRequestLocale,
   setRequestLocale,
 } from "../../src/server.js";
+import { snapshotLanguages } from "../../src/snapshot-languages.js";
 import { snapshotMessages } from "../../src/snapshot-messages.js";
-import { SUPPORTED_LOCALE_ROUTE_SYNTAXES } from "../../src/core.js";
 import {
   isTranslationConfigOptions,
   isTranslationMessages,
@@ -119,6 +119,49 @@ describe("better-translate internals", () => {
         messages: {},
       }),
     ).toThrow('Missing source messages for default locale "en".');
+    expect(() =>
+      normalizeConfig({
+        availableLocales: ["en", "es"] as const,
+        defaultLocale: "en",
+        messages: {
+          en,
+        },
+      }),
+    ).toThrow(
+      'Missing messages or loader for locale "es". Mark it optional with optionalLocales if translations are intentionally unavailable.',
+    );
+    expect(() =>
+      normalizeConfig({
+        availableLocales: ["en", "es"] as const,
+        defaultLocale: "en",
+        optionalLocales: ["fr"],
+        messages: {
+          en,
+        },
+      } as const),
+    ).toThrow(
+      'The locale "fr" is present in optionalLocales but not in availableLocales.',
+    );
+    expect(() =>
+      normalizeConfig({
+        availableLocales: ["en", "es"] as const,
+        defaultLocale: "en",
+        optionalLocales: ["en"],
+        messages: {
+          en,
+        },
+      } as const),
+    ).toThrow('The default locale "en" cannot be marked as optional.');
+    expect(() =>
+      normalizeConfig({
+        availableLocales: ["en", "es"] as const,
+        defaultLocale: "en",
+        optionalLocales: ["es"],
+        messages: {
+          en,
+        },
+      }),
+    ).not.toThrow();
     expect(() =>
       normalizeConfig({
         availableLocales: ["en"] as const,

--- a/packages/core/tests/types/core.global.typecheck.ts
+++ b/packages/core/tests/types/core.global.typecheck.ts
@@ -142,9 +142,9 @@ translate("account.balance.total");
 // @ts-expect-error missing params should fail for the configured helpers
 translate("common.greeting");
 
+// @ts-expect-error inferred params should reject unknown placeholder names
 translate("common.greeting", {
   params: {
-    // @ts-expect-error inferred params should reject unknown placeholder names
     user: "Ada",
   },
 });

--- a/packages/core/tests/types/core.typecheck.ts
+++ b/packages/core/tests/types/core.typecheck.ts
@@ -7,10 +7,10 @@ import type {
   TranslationLocaleMap,
 } from "@better-translate/core";
 import {
+  SUPPORTED_LOCALE_ROUTE_SYNTAXES,
   configureTranslations,
   getAvailableLanguages,
   getMessages,
-  SUPPORTED_LOCALE_ROUTE_SYNTAXES,
 } from "@better-translate/core";
 
 const en = {
@@ -134,11 +134,16 @@ getAvailableLanguages();
 getMessages();
 
 const configuredLanguages = translator.getAvailableLanguages();
-const configuredLanguageLocale: Locale | "fr" = configuredLanguages[0]!.locale;
-const configuredLanguage: TranslationLanguageMetadata<Locale | "fr"> =
-  configuredLanguages[0]!;
-void configuredLanguageLocale;
-void configuredLanguage;
+const configuredLanguage = configuredLanguages[0];
+
+if (configuredLanguage) {
+  const configuredLanguageLocale: Locale | "fr" = configuredLanguage.locale;
+  const configuredLanguageMetadata: TranslationLanguageMetadata<Locale | "fr"> =
+    configuredLanguage;
+
+  void configuredLanguageLocale;
+  void configuredLanguageMetadata;
+}
 void supportedLocaleRouteParamName;
 void firstSupportedLocaleRouteSyntax;
 
@@ -154,22 +159,22 @@ void invalidSupportedLocaleRouteParamName;
 // @ts-expect-error placeholder params should be required when the message contains tokens
 translator.t("common.greeting");
 
+// @ts-expect-error missing placeholder param should fail
 translator.t("common.greeting", {
-  // @ts-expect-error missing placeholder param should fail
   params: {},
 });
 
+// @ts-expect-error extra placeholder params should fail
 translator.t("common.greeting", {
   params: {
     name: "Ada",
-    // @ts-expect-error extra placeholder params should fail
     role: "Admin",
   },
 });
 
+// @ts-expect-error placeholder names should be inferred from the message string
 translator.t("common.formalGreeting", {
   params: {
-    // @ts-expect-error placeholder names should be inferred from the message string
     greeting: "Dr.",
     name: "Ada",
   },
@@ -183,6 +188,66 @@ configureTranslations({
   defaultLocale: "en",
   messages: {
     en,
+  },
+});
+
+const optionalLocaleTranslator = await configureTranslations({
+  availableLocales: ["en", "es", "fr"] as const,
+  defaultLocale: "en",
+  fallbackLocale: "en",
+  optionalLocales: ["es", "fr"],
+  messages: {
+    en,
+    es: {
+      common: {
+        hello: "Hola",
+      },
+    },
+  },
+});
+
+optionalLocaleTranslator.t("account.balance.label", { locale: "es" });
+optionalLocaleTranslator.t("account.balance.label", { locale: "fr" });
+optionalLocaleTranslator.loadLocale("fr");
+
+await configureTranslations({
+  availableLocales: ["en", "es"] as const,
+  defaultLocale: "en",
+  fallbackLocale: "en",
+  optionalLocales: ["es"],
+  languages: [
+    {
+      locale: "es",
+      nativeLabel: "Español",
+      optional: true,
+      shortLabel: "ES",
+    },
+  ],
+  messages: {
+    en,
+    es: {
+      account: {
+        balance: {
+          label: "Saldo",
+        },
+      },
+    },
+  },
+});
+
+configureTranslations({
+  availableLocales: ["en", "es"] as const,
+  defaultLocale: "en",
+  optionalLocales: ["es"],
+  messages: {
+    en,
+    // @ts-expect-error optional locale messages still reject extra keys
+    es: {
+      common: {
+        hello: "Hola",
+        extra: "Extra",
+      },
+    },
   },
 });
 
@@ -239,7 +304,6 @@ configureTranslations({
   ],
 });
 
-// @ts-expect-error languages should reject locales outside the declared locale contract
 configureTranslations({
   availableLocales: ["en", "es"] as const,
   defaultLocale: "en",
@@ -249,6 +313,7 @@ configureTranslations({
   },
   languages: [
     {
+      // @ts-expect-error languages should reject locales outside the declared locale contract
       locale: "pt",
       nativeLabel: "Português",
       shortLabel: "PT",
@@ -256,7 +321,6 @@ configureTranslations({
   ],
 });
 
-// @ts-expect-error directions should reject invalid direction values
 configureTranslations({
   availableLocales: ["en", "es"] as const,
   defaultLocale: "en",
@@ -265,11 +329,11 @@ configureTranslations({
     es,
   },
   directions: {
+    // @ts-expect-error directions should reject invalid direction values
     es: "sideways",
   },
 });
 
-// @ts-expect-error directions should reject locales outside the declared locale contract
 configureTranslations({
   availableLocales: ["en", "es"] as const,
   defaultLocale: "en",
@@ -278,6 +342,7 @@ configureTranslations({
     es,
   },
   directions: {
+    // @ts-expect-error directions should reject locales outside the declared locale contract
     pt: "rtl",
   },
 });


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

## Related Context

- Issue:
- Additional context:

## Testing

- [ ] `bun run lint`
- [ ] `bun run test`
- [ ] `bun run check-types`
- [ ] Other relevant checks were run when needed

## Changesets

- [ ] This PR includes a changeset for publishable package changes
- [ ] No changeset is needed because this change is docs-only, example-only, app-only, CI-only, or internal-only
- [ ] This PR targets the intended branch (`main` for releasable/website work or `next` when batching changes before a later merge to `main`)

## Release Flow

- [ ] I understand that package releases happen automatically after changesets reach `main`
- [ ] I understand that tags and GitHub Releases are created by GitHub Actions, not pushed manually from my machine

## Checklist

- [ ] Documentation was updated when needed
- [ ] Tests were added or updated when needed
- [ ] `bun.lock` was updated when dependencies changed
- [ ] Screenshots or reproduction details were included for behavior changes when helpful

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional locale support to `@better-translate/core` so you can ship incomplete or unavailable translations with safe fallbacks. The landing app now derives optional locales automatically and updates the Spanish label.

- **New Features**
  - Add `optionalLocales` to `configureTranslations` so non-default locales can be partial or missing; support `languages[].optional`.
  - Add validation: default locale cannot be optional; `optionalLocales` must exist in `availableLocales`; non-optional locales must provide messages or a loader.
  - Update types so only optional locales accept partial messages; docs and tests added; landing app derives `landingOptionalLocales` from locales/default and passes `optionalLocales` on the client.

- **Migration**
  - If a locale lacks messages or a loader, add it to `optionalLocales` or provide a loader/messages.
  - Do not mark the default locale optional.
  - Optionally set `languages[].optional = true` for metadata-only locales.

<sup>Written for commit 3b5fe5b8077dd31e14c4e7c2c30f60100c7cafb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jralvarenga/better-translate/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

